### PR TITLE
refactor: move the `Actor` module to the root

### DIFF
--- a/roguelike.cabal
+++ b/roguelike.cabal
@@ -11,24 +11,24 @@ executable roguelike
     main-is:          Main.hs
     ghc-options:      -threaded -Wall -Werror
 
-    other-modules:      Coord
+    other-modules:      Actor
+                      , Actor.Actions
+                      , Actor.Actions.Consume
+                      , Actor.Actions.Drop
+                      , Actor.Actions.Melee
+                      , Actor.Actions.Move
+                      , Actor.Actions.PickUp
+                      , Actor.Actions.Wait
+                      , Actor.NpcBehavior
+                      , Actor.Friendly
+                      , Actor.Inventory
+                      , Actor.Player
+                      , Actor.Monsters
+                      , Actor.Status
+                      , Actor.Status.Hp
+                      , Actor.Status.Experience
+                      , Coord
                       , Dungeon
-                      , Dungeon.Actor
-                      , Dungeon.Actor.Actions
-                      , Dungeon.Actor.Actions.Consume
-                      , Dungeon.Actor.Actions.Drop
-                      , Dungeon.Actor.Actions.Melee
-                      , Dungeon.Actor.Actions.Move
-                      , Dungeon.Actor.Actions.PickUp
-                      , Dungeon.Actor.Actions.Wait
-                      , Dungeon.Actor.NpcBehavior
-                      , Dungeon.Actor.Friendly
-                      , Dungeon.Actor.Inventory
-                      , Dungeon.Actor.Player
-                      , Dungeon.Actor.Monsters
-                      , Dungeon.Actor.Status
-                      , Dungeon.Actor.Status.Hp
-                      , Dungeon.Actor.Status.Experience
                       , Dungeon.Generate
                       , Dungeon.Generate.Room
                       , Dungeon.Init

--- a/src/Actor.hs
+++ b/src/Actor.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
 
-module Dungeon.Actor
+module Actor
     ( Actor
     , player
     , getLevel
@@ -30,21 +30,21 @@ module Dungeon.Actor
     , removeNthItem
     ) where
 
-import           Control.Lens            (makeLenses, (%~), (&), (.~), (^.))
-import           Control.Monad.Writer    (MonadWriter (writer), Writer)
-import           Coord                   (Coord)
-import           Data.Binary             (Binary)
-import           Data.Text               (Text)
-import           Dungeon.Actor.Inventory (Inventory, inventory)
-import qualified Dungeon.Actor.Inventory as I
-import           Dungeon.Actor.Status    (Status)
-import qualified Dungeon.Actor.Status    as S
-import           Dungeon.Actor.Status.Hp (hp)
-import           Dungeon.Item            (Item)
-import           GHC.Generics            (Generic)
-import           Localization            (MultilingualText)
-import qualified Localization.Texts      as T
-import           Log                     (MessageLog)
+import           Actor.Inventory      (Inventory, inventory)
+import qualified Actor.Inventory      as I
+import           Actor.Status         (Status)
+import qualified Actor.Status         as S
+import           Actor.Status.Hp      (hp)
+import           Control.Lens         (makeLenses, (%~), (&), (.~), (^.))
+import           Control.Monad.Writer (MonadWriter (writer), Writer)
+import           Coord                (Coord)
+import           Data.Binary          (Binary)
+import           Data.Text            (Text)
+import           Dungeon.Item         (Item)
+import           GHC.Generics         (Generic)
+import           Localization         (MultilingualText)
+import qualified Localization.Texts   as T
+import           Log                  (MessageLog)
 
 data ActorKind
     = Player

--- a/src/Actor/Actions.hs
+++ b/src/Actor/Actions.hs
@@ -1,12 +1,12 @@
-module Dungeon.Actor.Actions
+module Actor.Actions
     ( Action
     , ActionResult
     , ActionStatus(..)
     ) where
 
+import           Actor                      (Actor)
 import           Control.Monad.Trans.Writer (Writer)
 import           Dungeon                    (Dungeon)
-import           Dungeon.Actor              (Actor)
 import           Dungeon.Item.Book          (Book)
 import           Log                        (MessageLog)
 

--- a/src/Actor/Actions/Consume.hs
+++ b/src/Actor/Actions/Consume.hs
@@ -1,17 +1,17 @@
-module Dungeon.Actor.Actions.Consume
+module Actor.Actions.Consume
     ( consumeAction
     ) where
 
-import           Control.Lens          ((^.))
-import           Control.Monad.Writer  (tell)
-import           Dungeon               (pushActor)
-import           Dungeon.Actor         (healHp, name, removeNthItem)
-import           Dungeon.Actor.Actions (Action,
-                                        ActionStatus (Failed, Ok, ReadingStarted))
-import           Dungeon.Item          (Effect (Book, Heal), getEffect,
-                                        isUsableManyTimes)
-import           Dungeon.Item.Heal     (getHealAmount)
-import qualified Localization.Texts    as T
+import           Actor                (healHp, name, removeNthItem)
+import           Actor.Actions        (Action,
+                                       ActionStatus (Failed, Ok, ReadingStarted))
+import           Control.Lens         ((^.))
+import           Control.Monad.Writer (tell)
+import           Dungeon              (pushActor)
+import           Dungeon.Item         (Effect (Book, Heal), getEffect,
+                                       isUsableManyTimes)
+import           Dungeon.Item.Heal    (getHealAmount)
+import qualified Localization.Texts   as T
 
 consumeAction :: Int -> Action
 consumeAction n e d =

--- a/src/Actor/Actions/Drop.hs
+++ b/src/Actor/Actions/Drop.hs
@@ -1,14 +1,14 @@
-module Dungeon.Actor.Actions.Drop
+module Actor.Actions.Drop
     ( dropAction
     ) where
 
-import           Control.Lens          ((^.))
-import           Control.Monad.Writer  (tell)
-import           Dungeon               (pushActor, pushItem)
-import           Dungeon.Actor         (position, removeNthItem)
-import           Dungeon.Actor.Actions (Action, ActionStatus (Failed, Ok))
-import           Dungeon.Item          (Item, getName, setPosition)
-import qualified Localization.Texts    as T
+import           Actor                (position, removeNthItem)
+import           Actor.Actions        (Action, ActionStatus (Failed, Ok))
+import           Control.Lens         ((^.))
+import           Control.Monad.Writer (tell)
+import           Dungeon              (pushActor, pushItem)
+import           Dungeon.Item         (Item, getName, setPosition)
+import qualified Localization.Texts   as T
 
 dropAction :: Int -> Action
 dropAction n e d =

--- a/src/Actor/Actions/Melee.hs
+++ b/src/Actor/Actions/Melee.hs
@@ -1,15 +1,15 @@
-module Dungeon.Actor.Actions.Melee
+module Actor.Actions.Melee
     ( meleeAction
     ) where
 
-import           Control.Lens          ((^.))
-import           Control.Monad.Writer  (Writer)
-import           Dungeon               (Dungeon, popActorAt, pushActor)
-import           Dungeon.Actor         (Actor, position)
-import qualified Dungeon.Actor         as A
-import           Dungeon.Actor.Actions (Action, ActionStatus (Failed, Ok))
-import           Linear.V2             (V2)
-import           Log                   (MessageLog)
+import           Actor                (Actor, position)
+import qualified Actor                as A
+import           Actor.Actions        (Action, ActionStatus (Failed, Ok))
+import           Control.Lens         ((^.))
+import           Control.Monad.Writer (Writer)
+import           Dungeon              (Dungeon, popActorAt, pushActor)
+import           Linear.V2            (V2)
+import           Log                  (MessageLog)
 
 meleeAction :: V2 Int -> Action
 meleeAction offset src dungeon = result

--- a/src/Actor/Actions/Move.hs
+++ b/src/Actor/Actions/Move.hs
@@ -1,19 +1,19 @@
-module Dungeon.Actor.Actions.Move
+module Actor.Actions.Move
     ( moveAction
     ) where
 
-import           Control.Lens          ((&), (.~), (^.))
-import           Control.Monad.Writer  (tell)
-import           Coord                 (Coord)
-import           Data.Array            ((!))
-import           Data.Maybe            (isNothing)
-import           Dungeon               (Dungeon, actorAt, mapWidthAndHeight,
-                                        pushActor, tileMap)
-import           Dungeon.Actor         (Actor, position)
-import           Dungeon.Actor.Actions (Action, ActionStatus (Failed, Ok))
-import           Dungeon.Map.Tile      (walkable)
-import           Linear.V2             (V2 (V2))
-import qualified Localization.Texts    as T
+import           Actor                (Actor, position)
+import           Actor.Actions        (Action, ActionStatus (Failed, Ok))
+import           Control.Lens         ((&), (.~), (^.))
+import           Control.Monad.Writer (tell)
+import           Coord                (Coord)
+import           Data.Array           ((!))
+import           Data.Maybe           (isNothing)
+import           Dungeon              (Dungeon, actorAt, mapWidthAndHeight,
+                                       pushActor, tileMap)
+import           Dungeon.Map.Tile     (walkable)
+import           Linear.V2            (V2 (V2))
+import qualified Localization.Texts   as T
 
 moveAction :: V2 Int -> Action
 moveAction offset src d =

--- a/src/Actor/Actions/PickUp.hs
+++ b/src/Actor/Actions/PickUp.hs
@@ -1,15 +1,15 @@
-module Dungeon.Actor.Actions.PickUp
+module Actor.Actions.PickUp
     ( pickUpAction
     ) where
 
-import           Control.Lens            ((&), (.~), (^.))
-import           Control.Monad.Writer    (tell)
-import           Dungeon                 (popItemAt, pushActor)
-import           Dungeon.Actor           (inventoryItems, position)
-import           Dungeon.Actor.Actions   (Action, ActionStatus (Failed, Ok))
-import           Dungeon.Actor.Inventory (addItem)
-import           Dungeon.Item            (getName)
-import qualified Localization.Texts      as T
+import           Actor                (inventoryItems, position)
+import           Actor.Actions        (Action, ActionStatus (Failed, Ok))
+import           Actor.Inventory      (addItem)
+import           Control.Lens         ((&), (.~), (^.))
+import           Control.Monad.Writer (tell)
+import           Dungeon              (popItemAt, pushActor)
+import           Dungeon.Item         (getName)
+import qualified Localization.Texts   as T
 
 pickUpAction :: Action
 pickUpAction e d =

--- a/src/Actor/Actions/Wait.hs
+++ b/src/Actor/Actions/Wait.hs
@@ -1,0 +1,9 @@
+module Actor.Actions.Wait
+    ( waitAction
+    ) where
+
+import           Actor.Actions (Action, ActionStatus (Ok))
+import           Dungeon       (pushActor)
+
+waitAction :: Action
+waitAction e d = return (Ok, pushActor e d)

--- a/src/Actor/Friendly.hs
+++ b/src/Actor/Friendly.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Dungeon.Actor.Friendly
+module Actor.Friendly
     ( electria
     ) where
 
-import           Coord                   (Coord)
-import           Data.Text               (Text)
-import           Dungeon.Actor           (Actor, ActorKind (FriendlyNpc), actor)
-import           Dungeon.Actor.Status    (Status, status)
-import           Dungeon.Actor.Status.Hp (hp)
-import           Localization            (MultilingualText)
-import qualified Localization.Texts      as T
+import           Actor              (Actor, ActorKind (FriendlyNpc), actor)
+import           Actor.Status       (Status, status)
+import           Actor.Status.Hp    (hp)
+import           Coord              (Coord)
+import           Data.Text          (Text)
+import           Localization       (MultilingualText)
+import qualified Localization.Texts as T
 
 electria :: Coord -> Actor
 electria position =

--- a/src/Actor/Inventory.hs
+++ b/src/Actor/Inventory.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric   #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Dungeon.Actor.Inventory
+module Actor.Inventory
     ( Inventory
     , inventory
     , addItem

--- a/src/Actor/Monsters.hs
+++ b/src/Actor/Monsters.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Dungeon.Actor.Monsters
+module Actor.Monsters
     ( orc
     , troll
     ) where
 
-import           Coord                   (Coord)
-import           Dungeon.Actor           (Actor, monster)
-import           Dungeon.Actor.Status    (status)
-import           Dungeon.Actor.Status.Hp (hp)
-import qualified Localization.Texts      as T
+import           Actor              (Actor, monster)
+import           Actor.Status       (status)
+import           Actor.Status.Hp    (hp)
+import           Coord              (Coord)
+import qualified Localization.Texts as T
 
 orc :: Coord -> Actor
 orc c = monster c T.orc st "images/orc.png"

--- a/src/Actor/NpcBehavior.hs
+++ b/src/Actor/NpcBehavior.hs
@@ -1,22 +1,21 @@
-module Dungeon.Actor.NpcBehavior
+module Actor.NpcBehavior
     ( handleNpcTurns
     ) where
 
-import           Control.Lens                ((&), (.~), (^.))
-import           Control.Monad.Writer        (MonadWriter (writer), Writer)
-import           Coord                       (Coord)
-import           Data.Maybe                  (fromMaybe)
-import           Dungeon                     (Dungeon, getPlayerActor, npcs,
-                                              popActorAt)
-import           Dungeon.Actor               (Actor, pathToDestination,
-                                              position)
-import           Dungeon.Actor.Actions       (Action)
-import           Dungeon.Actor.Actions.Melee (meleeAction)
-import           Dungeon.Actor.Actions.Move  (moveAction)
-import           Dungeon.Actor.Actions.Wait  (waitAction)
-import           Dungeon.PathFinder          (getPathTo)
-import           Linear.V2                   (V2 (V2))
-import           Log                         (MessageLog)
+import           Actor                (Actor, pathToDestination, position)
+import           Actor.Actions        (Action)
+import           Actor.Actions.Melee  (meleeAction)
+import           Actor.Actions.Move   (moveAction)
+import           Actor.Actions.Wait   (waitAction)
+import           Control.Lens         ((&), (.~), (^.))
+import           Control.Monad.Writer (MonadWriter (writer), Writer)
+import           Coord                (Coord)
+import           Data.Maybe           (fromMaybe)
+import           Dungeon              (Dungeon, getPlayerActor, npcs,
+                                       popActorAt)
+import           Dungeon.PathFinder   (getPathTo)
+import           Linear.V2            (V2 (V2))
+import           Log                  (MessageLog)
 
 handleNpcTurns :: Dungeon -> Writer MessageLog Dungeon
 handleNpcTurns d = foldl foldStep (writer (d, [])) $ npcs d

--- a/src/Actor/Player.hs
+++ b/src/Actor/Player.hs
@@ -1,4 +1,4 @@
-module Dungeon.Actor.Player
+module Actor.Player
     ( playerBumpAction
     , handlePlayerMoving
     , handlePlayerPickingUp
@@ -8,18 +8,18 @@ module Dungeon.Actor.Player
     , handlePlayerDropItem
     ) where
 
+import           Actor                                (Actor, isMonster,
+                                                       talkMessage)
+import qualified Actor                                as A
+import           Actor.Actions                        (ActionStatus (Failed, Ok, ReadingStarted))
+import           Actor.Actions.Consume                (consumeAction)
+import           Actor.Actions.Drop                   (dropAction)
+import           Actor.Actions.Melee                  (meleeAction)
+import           Actor.Actions.Move                   (moveAction)
+import           Actor.Actions.PickUp                 (pickUpAction)
 import           Control.Lens                         ((^.))
 import           Data.Maybe                           (fromMaybe)
 import           Dungeon                              (isTown)
-import           Dungeon.Actor                        (Actor, isMonster,
-                                                       talkMessage)
-import qualified Dungeon.Actor                        as A
-import           Dungeon.Actor.Actions                (ActionStatus (Failed, Ok, ReadingStarted))
-import           Dungeon.Actor.Actions.Consume        (consumeAction)
-import           Dungeon.Actor.Actions.Drop           (dropAction)
-import           Dungeon.Actor.Actions.Melee          (meleeAction)
-import           Dungeon.Actor.Actions.Move           (moveAction)
-import           Dungeon.Actor.Actions.PickUp         (pickUpAction)
 import           GameModel.Status                     (GameStatus (Exploring, GameOver, ReadingBook, SelectingItemToDrop, SelectingItemToUse, Talking))
 import           GameModel.Status.Exploring           (ExploringHandler,
                                                        actorAt,

--- a/src/Actor/Status.hs
+++ b/src/Actor/Status.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module Dungeon.Actor.Status
+module Actor.Status
     ( Status
     , status
     , getLevel
@@ -14,17 +14,17 @@ module Dungeon.Actor.Status
     , getDefence
     ) where
 
-import           Data.Binary                     (Binary)
-import           Data.Maybe                      (isNothing)
-import           Dungeon.Actor.Status.Experience (Experience, gainExperience)
-import qualified Dungeon.Actor.Status.Experience as E
-import           Dungeon.Actor.Status.Hp         (Hp)
-import qualified Dungeon.Actor.Status.Hp         as HP
-import           GHC.Generics                    (Generic)
-import           Localization                    (MultilingualText)
-import qualified Localization.Texts              as T
-import           Log                             (MessageLog)
-import qualified Log                             as M
+import           Actor.Status.Experience (Experience, gainExperience)
+import qualified Actor.Status.Experience as E
+import           Actor.Status.Hp         (Hp)
+import qualified Actor.Status.Hp         as HP
+import           Data.Binary             (Binary)
+import           Data.Maybe              (isNothing)
+import           GHC.Generics            (Generic)
+import           Localization            (MultilingualText)
+import qualified Localization.Texts      as T
+import           Log                     (MessageLog)
+import qualified Log                     as M
 
 data Status =
     Status

--- a/src/Actor/Status/Experience.hs
+++ b/src/Actor/Status/Experience.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module Dungeon.Actor.Status.Experience
+module Actor.Status.Experience
     ( Experience
     , experience
     , getCurrentExperiencePoint

--- a/src/Actor/Status/Hp.hs
+++ b/src/Actor/Status/Hp.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module Dungeon.Actor.Status.Hp
+module Actor.Status.Hp
     ( Hp
     , hp
     , getHp

--- a/src/Dungeon.hs
+++ b/src/Dungeon.hs
@@ -38,14 +38,14 @@ module Dungeon
     , pushItem
     ) where
 
+import           Actor                (Actor, isPlayer)
+import qualified Actor                as A
 import           Control.Lens         (makeLenses, (%~), (&), (.~), (^.))
 import           Coord                (Coord)
 import           Data.Array.Base      (IArray (bounds), assocs, (//))
 import           Data.Binary          (Binary)
 import           Data.Foldable        (find)
 import           Data.List            (findIndex)
-import           Dungeon.Actor        (Actor, isPlayer)
-import qualified Dungeon.Actor        as A
 import           Dungeon.Item         (Item)
 import qualified Dungeon.Item         as I
 import           Dungeon.Map.Bool     (BoolMap)

--- a/src/Dungeon/Actor/Actions/Wait.hs
+++ b/src/Dungeon/Actor/Actions/Wait.hs
@@ -1,9 +1,0 @@
-module Dungeon.Actor.Actions.Wait
-    ( waitAction
-    ) where
-
-import           Dungeon               (pushActor)
-import           Dungeon.Actor.Actions (Action, ActionStatus (Ok))
-
-waitAction :: Action
-waitAction e d = return (Ok, pushActor e d)

--- a/src/Dungeon/Generate.hs
+++ b/src/Dungeon/Generate.hs
@@ -2,32 +2,32 @@ module Dungeon.Generate
     ( generateMultipleFloorsDungeon
     ) where
 
-import           Control.Lens           ((^.))
-import           Coord                  (Coord)
-import           Data.Array             (bounds, (//))
-import           Data.Maybe             (fromMaybe)
-import           Data.Tree              (Tree (Node, rootLabel, subForest))
-import           Dungeon                (Dungeon, DungeonKind (DungeonType),
-                                         addAscendingAndDescendingStiars,
-                                         changeTile, dungeon,
-                                         stairsPositionCandidates)
-import           Dungeon.Actor          (Actor)
-import qualified Dungeon.Actor          as A
-import           Dungeon.Actor.Monsters (orc, troll)
-import           Dungeon.Generate.Room  (Room (..), center,
-                                         roomFromTwoPositionInclusive,
-                                         roomFromWidthHeight, roomOverlaps)
-import           Dungeon.Item           (Item, herb, sampleBook)
-import qualified Dungeon.Item           as I
-import           Dungeon.Map.Tile       (TileMap, allWallTiles, downStairs,
-                                         floorTile, upStairs)
-import           Dungeon.Size           (maxSize, minSize)
-import           Dungeon.Stairs         (StairsPair (StairsPair))
-import           Linear.V2              (V2 (..), _x, _y)
-import           System.Random          (Random (randomR), StdGen, random)
-import           TreeZipper             (TreeZipper, appendNode, getFocused,
-                                         goDownBy, goToRootAndGetTree, modify,
-                                         treeZipper)
+import           Actor                 (Actor)
+import qualified Actor                 as A
+import           Actor.Monsters        (orc, troll)
+import           Control.Lens          ((^.))
+import           Coord                 (Coord)
+import           Data.Array            (bounds, (//))
+import           Data.Maybe            (fromMaybe)
+import           Data.Tree             (Tree (Node, rootLabel, subForest))
+import           Dungeon               (Dungeon, DungeonKind (DungeonType),
+                                        addAscendingAndDescendingStiars,
+                                        changeTile, dungeon,
+                                        stairsPositionCandidates)
+import           Dungeon.Generate.Room (Room (..), center,
+                                        roomFromTwoPositionInclusive,
+                                        roomFromWidthHeight, roomOverlaps)
+import           Dungeon.Item          (Item, herb, sampleBook)
+import qualified Dungeon.Item          as I
+import           Dungeon.Map.Tile      (TileMap, allWallTiles, downStairs,
+                                        floorTile, upStairs)
+import           Dungeon.Size          (maxSize, minSize)
+import           Dungeon.Stairs        (StairsPair (StairsPair))
+import           Linear.V2             (V2 (..), _x, _y)
+import           System.Random         (Random (randomR), StdGen, random)
+import           TreeZipper            (TreeZipper, appendNode, getFocused,
+                                        goDownBy, goToRootAndGetTree, modify,
+                                        treeZipper)
 
 generateMultipleFloorsDungeon ::
        StdGen

--- a/src/Dungeon/Init.hs
+++ b/src/Dungeon/Init.hs
@@ -2,9 +2,9 @@ module Dungeon.Init
     ( initDungeon
     ) where
 
+import           Actor                     (player)
 import           Data.Maybe                (fromMaybe)
 import           Dungeon                   (Dungeon, updateMap)
-import           Dungeon.Actor             (player)
 import           Dungeon.Predefined.Beaeve (beaeve)
 import           Linear.V2                 (V2 (V2))
 

--- a/src/Dungeon/Predefined/Beaeve.hs
+++ b/src/Dungeon/Predefined/Beaeve.hs
@@ -2,13 +2,12 @@ module Dungeon.Predefined.Beaeve
     ( beaeve
     ) where
 
-import           Data.Array             ((//))
-import           Dungeon                (Dungeon, DungeonKind (Town), dungeon)
-import           Dungeon.Actor          (Actor)
-import           Dungeon.Actor.Friendly (electria)
-import           Dungeon.Map.Tile       (TileMap, allWallTiles, floorTile,
-                                         wallTile)
-import           Linear.V2              (V2 (V2))
+import           Actor            (Actor)
+import           Actor.Friendly   (electria)
+import           Data.Array       ((//))
+import           Dungeon          (Dungeon, DungeonKind (Town), dungeon)
+import           Dungeon.Map.Tile (TileMap, allWallTiles, floorTile, wallTile)
+import           Linear.V2        (V2 (V2))
 
 beaeve :: Actor -> Dungeon
 beaeve player =

--- a/src/GameModel/Status/Exploring.hs
+++ b/src/GameModel/Status/Exploring.hs
@@ -17,6 +17,8 @@ module GameModel.Status.Exploring
     , getMessageLog
     ) where
 
+import           Actor                               (Actor)
+import           Actor.Actions                       (Action, ActionStatus)
 import           Control.Lens                        (makeLenses, (%~), (&),
                                                       (.~), (^.))
 import           Control.Monad.Trans.Writer          (runWriter)
@@ -24,8 +26,6 @@ import           Coord                               (Coord)
 import           Data.Binary                         (Binary)
 import           Dungeon                             (Dungeon)
 import qualified Dungeon                             as D
-import           Dungeon.Actor                       (Actor)
-import           Dungeon.Actor.Actions               (Action, ActionStatus)
 import           GHC.Generics                        (Generic)
 import           GameModel.Status.Exploring.Dungeons (Dungeons)
 import qualified GameModel.Status.Exploring.Dungeons as DS

--- a/src/GameModel/Status/Exploring/Dungeons.hs
+++ b/src/GameModel/Status/Exploring/Dungeons.hs
@@ -7,6 +7,9 @@ module GameModel.Status.Exploring.Dungeons
     , handleNpcTurns
     ) where
 
+import           Actor                      (Actor, isPlayer, position)
+import           Actor.Actions              (Action, ActionStatus (Failed))
+import qualified Actor.NpcBehavior          as NPC
 import           Control.Lens               ((%~), (&), (.~), (^.))
 import           Control.Monad.Trans.Writer (Writer)
 import           Data.Foldable              (find)
@@ -15,9 +18,6 @@ import           Dungeon                    (Dungeon, actors, ascendingStairs,
                                              descendingStairs,
                                              positionOnParentMap, updateMap)
 import qualified Dungeon                    as D
-import           Dungeon.Actor              (Actor, isPlayer, position)
-import           Dungeon.Actor.Actions      (Action, ActionStatus (Failed))
-import qualified Dungeon.Actor.NpcBehavior  as NPC
 import           Dungeon.Stairs             (StairsPair (StairsPair, downStairs, upStairs))
 import           Log                        (MessageLog)
 import           TreeZipper                 (TreeZipper, getFocused, goDownBy,

--- a/src/Talking.hs
+++ b/src/Talking.hs
@@ -8,11 +8,11 @@ module Talking
     , message
     ) where
 
-import           Control.Lens  (makeLenses)
-import           Data.Binary   (Binary)
-import           Dungeon.Actor (Actor)
-import           GHC.Generics  (Generic)
-import           Localization  (MultilingualText)
+import           Actor        (Actor)
+import           Control.Lens (makeLenses)
+import           Data.Binary  (Binary)
+import           GHC.Generics (Generic)
+import           Localization (MultilingualText)
 
 data TalkWith =
     TalkWith

--- a/src/UI/Draw/Exploring.hs
+++ b/src/UI/Draw/Exploring.hs
@@ -4,6 +4,12 @@ module UI.Draw.Exploring
     ( drawExploring
     ) where
 
+import           Actor                      (getCurrentExperiencePoint,
+                                             getDefence,
+                                             getExperiencePointForNextLevel,
+                                             getHp, getLevel, getMaxHp,
+                                             getPower, walkingImagePath)
+import qualified Actor                      as A
 import           Control.Lens               ((&), (.~), (^.))
 import           Control.Monad              (guard)
 import           Coord                      (Coord)
@@ -12,12 +18,6 @@ import           Data.Maybe                 (mapMaybe)
 import           Dungeon                    (Dungeon, actors, explored, items,
                                              mapWidthAndHeight, playerPosition,
                                              tileMap, visible)
-import           Dungeon.Actor              (getCurrentExperiencePoint,
-                                             getDefence,
-                                             getExperiencePointForNextLevel,
-                                             getHp, getLevel, getMaxHp,
-                                             getPower, walkingImagePath)
-import qualified Dungeon.Actor              as A
 import qualified Dungeon.Item               as I
 import qualified Dungeon.Map.Tile           as MT
 import           GameModel.Config           (Config)

--- a/src/UI/Draw/Talking.hs
+++ b/src/UI/Draw/Talking.hs
@@ -4,8 +4,8 @@ module UI.Draw.Talking
     ( drawTalking
     ) where
 
+import           Actor                    (standingImagePath)
 import           Control.Lens             ((&), (.~), (^.))
-import           Dungeon.Actor            (standingImagePath)
 import           GameModel.Config         (Config)
 import           GameModel.Status.Talking (TalkingHandler, destructHandler)
 import           Localization             (getLocalizedText)

--- a/src/UI/Event.hs
+++ b/src/UI/Event.hs
@@ -4,14 +4,14 @@ module UI.Event
     ( handleEvent
     ) where
 
-import           Data.Maybe                           (fromMaybe)
-import           Data.Text                            (Text)
-import           Dungeon.Actor.Player                 (handlePlayerConsumeItem,
+import           Actor.Player                         (handlePlayerConsumeItem,
                                                        handlePlayerDropItem,
                                                        handlePlayerMoving,
                                                        handlePlayerPickingUp,
                                                        handlePlayerSelectingItemToDrop,
                                                        handlePlayerSelectingItemToUse)
+import           Data.Maybe                           (fromMaybe)
+import           Data.Text                            (Text)
 import           GameModel                            (GameModel (GameModel, config, status))
 import           GameModel.Config                     (Language (English, Japanese),
                                                        setLocale, writeConfig)


### PR DESCRIPTION
Haskell's visibility has two types: visible from any other modules or private. It is different from Rust's one, where the programmers can specify which modules can see the functions (using pub (crate), pub(super), etc.). So, we do not need to create a hierarchy unless to avoid name conflictions. There is no other `Actors` module, so I moved the module to the root.
