### PR TITLE
ci: run `cabal clean` before `cabal build`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -42,7 +42,9 @@ jobs:
       run: "echo \"package * \n  ghc-options: -fwrite-ide-info\" > cabal.project.local"
 
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: |
+        cabal clean # This is needed to run `weeder` correctly.
+        cabal build --enable-tests --enable-benchmarks all
 
     - name: Detect unused lines
       run: |


### PR DESCRIPTION
To run `weeder` correctly.
