### PR TITLE
refactor: s/completeThisTurn/processAfterPlayerTurn

### DIFF
--- a/src/GameStatus/Exploring.hs
+++ b/src/GameStatus/Exploring.hs
@@ -8,7 +8,7 @@ module GameStatus.Exploring
     , descendStairsAtPlayerPosition
     , exitDungeon
     , doPlayerAction
-    , completeThisTurn
+    , processAfterPlayerTurn
     , getPlayerActor
     , getPlayerPosition
     , actorAt
@@ -69,8 +69,8 @@ doPlayerAction action eh = (status, newHandler)
         eh & messageLog %~ L.addMessages newLog &
         dungeons .~ dungeonsAfterAction
 
-completeThisTurn :: ExploringHandler -> Maybe ExploringHandler
-completeThisTurn eh =
+processAfterPlayerTurn :: ExploringHandler -> Maybe ExploringHandler
+processAfterPlayerTurn eh =
     (\x -> handlerAfterNpcTurns & dungeons %~ modify (const x)) <$>
     newCurrentDungeon
   where

--- a/src/GameStatus/ReadingBook.hs
+++ b/src/GameStatus/ReadingBook.hs
@@ -9,7 +9,7 @@ module GameStatus.ReadingBook
 
 import           Data.Binary          (Binary)
 import           GHC.Generics         (Generic)
-import           GameStatus.Exploring (ExploringHandler, completeThisTurn)
+import           GameStatus.Exploring (ExploringHandler, processAfterPlayerTurn)
 import           Localization         (MultilingualText)
 
 data ReadingBookHandler =
@@ -28,4 +28,4 @@ getContent :: ReadingBookHandler -> MultilingualText
 getContent (ReadingBookHandler c _) = c
 
 finishReading :: ReadingBookHandler -> Maybe ExploringHandler
-finishReading (ReadingBookHandler _ h) = completeThisTurn h
+finishReading (ReadingBookHandler _ h) = processAfterPlayerTurn h

--- a/src/Player.hs
+++ b/src/Player.hs
@@ -19,7 +19,7 @@ import           Data.Maybe               (fromMaybe)
 import           Dungeon                  (isTown)
 import           GameStatus               (GameStatus (Exploring, GameOver, ReadingBook, SelectingItem, Talking))
 import           GameStatus.Exploring     (ExploringHandler, actorAt,
-                                           completeThisTurn, doPlayerAction,
+                                           processAfterPlayerTurn, doPlayerAction,
                                            getCurrentDungeon, getPlayerActor,
                                            getPlayerPosition,
                                            isPositionInDungeon)
@@ -40,7 +40,7 @@ handlePlayerMoving offset gs =
      in if isSuccess
             then case newState of
                      Exploring eh ->
-                         maybe GameOver Exploring (completeThisTurn eh)
+                         maybe GameOver Exploring (processAfterPlayerTurn eh)
                      _ -> newState
             else newState
 
@@ -48,7 +48,7 @@ handlePlayerPickingUp :: ExploringHandler -> GameStatus
 handlePlayerPickingUp eh =
     let (status, newHandler) = doPlayerAction pickUpAction eh
      in case status of
-            Ok -> maybe GameOver Exploring $ completeThisTurn newHandler
+            Ok -> maybe GameOver Exploring $ processAfterPlayerTurn newHandler
             ReadingStarted _ -> error "Unreachable."
             Failed -> Exploring newHandler
 
@@ -68,7 +68,7 @@ handlePlayerAfterSelecting h = result
             Nothing -> SelectingItem h
     newState status handlerAfterAction =
         case status of
-            Ok -> maybe GameOver Exploring $ completeThisTurn handlerAfterAction
+            Ok -> maybe GameOver Exploring $ processAfterPlayerTurn handlerAfterAction
             ReadingStarted book ->
                 ReadingBook $ readingBookHandler book handlerAfterAction
             Failed -> Exploring handlerAfterAction


### PR DESCRIPTION
The previous name was ambiguous because it did not say from which status
the function proceeded.
