### PR TITLE
refactor: define `Actor.Identifier`

### DIFF
--- a/roguelike.cabal
+++ b/roguelike.cabal
@@ -22,6 +22,7 @@ executable roguelike
                       , Actor.NpcBehavior
                       , Actor.Friendly
                       , Actor.Friendly.Electria
+                      , Actor.Identifier
                       , Actor.Inventory
                       , Actor.Monsters
                       , Actor.Status

--- a/src/Action/Consume.hs
+++ b/src/Action/Consume.hs
@@ -4,8 +4,8 @@ module Action.Consume
 
 import           Action               (Action, ActionResult (ActionResult),
                                        ActionStatus (Failed, Ok, ReadingStarted))
-import           Actor                (healHp, name, removeNthItem)
-import           Control.Lens         ((^.))
+import           Actor                (getIdentifier, healHp, removeNthItem)
+import           Actor.Identifier     (toName)
 import           Control.Monad.Writer (tell)
 import           Dungeon              (pushActor)
 import           Item                 (Effect (Book, Heal), getEffect,
@@ -31,7 +31,7 @@ consumeAction n e d =
 
 doItemEffect :: Effect -> Action
 doItemEffect (Heal handler) actor dungeon = do
-    tell [T.healed (actor ^. name) amount]
+    tell [T.healed (toName $ getIdentifier actor) amount]
     return $ ActionResult Ok $ pushActor (healHp amount actor) dungeon
   where
     amount = getHealAmount handler

--- a/src/Actor/Friendly.hs
+++ b/src/Actor/Friendly.hs
@@ -3,18 +3,12 @@ module Actor.Friendly
     ) where
 
 import           Actor                   (Actor, ActorKind (FriendlyNpc), actor)
+import           Actor.Identifier        (Identifier)
 import           Actor.Status            (Status)
 import           Coord                   (Coord)
 import           Data.Text               (Text)
 import           GameStatus.Talking.Part (TalkingPart)
-import           Localization            (MultilingualText)
 
 friendly ::
-       Coord
-    -> MultilingualText
-    -> Status
-    -> TalkingPart
-    -> Text
-    -> Text
-    -> Actor
+       Coord -> Identifier -> Status -> TalkingPart -> Text -> Text -> Actor
 friendly position name st p = actor position name st FriendlyNpc (Just p)

--- a/src/Actor/Friendly/Electria.hs
+++ b/src/Actor/Friendly/Electria.hs
@@ -6,6 +6,7 @@ module Actor.Friendly.Electria
 
 import           Actor                   (Actor)
 import           Actor.Friendly          (friendly)
+import           Actor.Identifier        (Identifier (Electria))
 import           Actor.Status            (status)
 import           Actor.Status.Hp         (hp)
 import           Coord                   (Coord)
@@ -18,7 +19,7 @@ electria :: Coord -> Actor
 electria position =
     friendly
         position
-        T.electria
+        Electria
         st
         talking
         "images/electria.png"

--- a/src/Actor/Identifier.hs
+++ b/src/Actor/Identifier.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Actor.Identifier
+    ( Identifier(..)
+    , toName
+    ) where
+
+import           Data.Binary        (Binary)
+import           GHC.Generics       (Generic)
+import           Localization       (MultilingualText)
+import qualified Localization.Texts as T
+
+data Identifier
+    = Orc
+    | Troll
+    | Electria
+    | Player
+    deriving (Show, Ord, Eq, Generic)
+
+instance Binary Identifier
+
+toName :: Identifier -> MultilingualText
+toName Orc      = T.orc
+toName Troll    = T.troll
+toName Electria = T.electria
+toName Player   = T.player

--- a/src/Actor/Monsters.hs
+++ b/src/Actor/Monsters.hs
@@ -5,18 +5,18 @@ module Actor.Monsters
     , troll
     ) where
 
-import           Actor              (Actor, monster)
-import           Actor.Status       (status)
-import           Actor.Status.Hp    (hp)
-import           Coord              (Coord)
-import qualified Localization.Texts as T
+import           Actor            (Actor, monster)
+import           Actor.Identifier (Identifier (Orc, Troll))
+import           Actor.Status     (status)
+import           Actor.Status.Hp  (hp)
+import           Coord            (Coord)
 
 orc :: Coord -> Actor
-orc c = monster c T.orc st "images/orc.png"
+orc c = monster c Orc st "images/orc.png"
   where
     st = status (hp 10) 0 3
 
 troll :: Coord -> Actor
-troll c = monster c T.troll st "images/troll.png"
+troll c = monster c Troll st "images/troll.png"
   where
     st = status (hp 16) 1 4


### PR DESCRIPTION
To resolve the circular dependencies between Actor, Talking, and Quest.
