### PR TITLE
refactor: do not take an `Actor` value

### DIFF
--- a/src/Dungeon/Init.hs
+++ b/src/Dungeon/Init.hs
@@ -4,7 +4,7 @@ module Dungeon.Init
 
 import           Actor                     (player)
 import           Data.Maybe                (fromMaybe)
-import           Dungeon                   (Dungeon, updateMap)
+import           Dungeon                   (Dungeon, pushActor, updateMap)
 import           Dungeon.Predefined.Beaeve (beaeve)
 import           Linear.V2                 (V2 (V2))
 
@@ -12,4 +12,4 @@ initDungeon :: Dungeon
 initDungeon =
     fromMaybe
         (error "Failed to initialize the first map.")
-        (updateMap $ beaeve $ player $ V2 5 5)
+        (updateMap $ pushActor (player $ V2 5 5) beaeve)

--- a/src/Dungeon/Predefined/Beaeve.hs
+++ b/src/Dungeon/Predefined/Beaeve.hs
@@ -2,7 +2,6 @@ module Dungeon.Predefined.Beaeve
     ( beaeve
     ) where
 
-import           Actor                   (Actor)
 import           Actor.Friendly.Electria (electria)
 import           Data.Array              ((//))
 import           Dungeon                 (Dungeon, dungeon)
@@ -11,8 +10,8 @@ import           Dungeon.Map.Tile        (TileMap, allWallTiles, floorTile,
                                           wallTile)
 import           Linear.V2               (V2 (V2))
 
-beaeve :: Actor -> Dungeon
-beaeve player =
+beaeve :: Dungeon
+beaeve =
     dungeon
         (stringArrayToMap
              [ "#########################"
@@ -30,7 +29,7 @@ beaeve player =
              , "#.......................#"
              , "#####......##############"
              ])
-        [player, electria $ V2 4 5]
+        [electria $ V2 4 5]
         []
         Beaeve
 


### PR DESCRIPTION
The other predefined dungeon generator does not take an `Actor` value.
