### PR TITLE
fix: forgot to compare room minimum size and map size

### DIFF
--- a/src/Dungeon/Generate/Config.hs
+++ b/src/Dungeon/Generate/Config.hs
@@ -44,11 +44,7 @@ config nf mr rmin rmax ms@(V2 width _)
     | mr <= 0 = error maxRoomMustBePositive
     | rmin <= 0 = error roomMinSizeMustBePositive
     | rmin > rmax = error $ roomMinIsLargerThanRoomMax rmin rmax -- No need to check if `rmax <= 0` as this ensures that `0 < rmin <= rmax`.
-    | rmin > width =
-        error $
-        "The room minimum size " ++
-        show rmin ++
-        " is larger than or equal to the map width " ++ show width ++ "."
+    | rmin > width = error $ roomMinSizeIsLargerThanRoomWidth rmin width
     | otherwise = Config nf mr rmin rmax ms
 
 numOfFloorsMustBePositive :: String
@@ -65,3 +61,9 @@ roomMinIsLargerThanRoomMax rmin rmax =
     "The room minimum size " ++
     show rmin ++
     " is larger than or equal to the room maximum size " ++ show rmax ++ "."
+
+roomMinSizeIsLargerThanRoomWidth :: Int -> Int -> String
+roomMinSizeIsLargerThanRoomWidth rmin width =
+    "The room minimum size " ++
+    show rmin ++
+    " is larger than or equal to the map width " ++ show width ++ "."

--- a/src/Dungeon/Generate/Config.hs
+++ b/src/Dungeon/Generate/Config.hs
@@ -39,12 +39,17 @@ getMapSize :: Config -> V2 Int
 getMapSize = mapSize
 
 config :: Int -> Int -> Int -> Int -> V2 Int -> Config
-config nf mr rmin rmax ms@(V2 width _)
+config nf mr rmin rmax ms@(V2 width height)
     | nf <= 0 = error numOfFloorsMustBePositive
     | mr <= 0 = error maxRoomMustBePositive
     | rmin <= 0 = error roomMinSizeMustBePositive
     | rmin > rmax = error $ roomMinIsLargerThanRoomMax rmin rmax -- No need to check if `rmax <= 0` as this ensures that `0 < rmin <= rmax`.
     | rmin > width = error $ roomMinSizeIsLargerThanRoomWidth rmin width
+    | rmin > height =
+        error $
+        "The room minimum size " ++
+        show rmin ++
+        " is larger than or equal to the map height " ++ show height ++ "."
     | otherwise = Config nf mr rmin rmax ms
 
 numOfFloorsMustBePositive :: String

--- a/src/Dungeon/Generate/Config.hs
+++ b/src/Dungeon/Generate/Config.hs
@@ -45,11 +45,7 @@ config nf mr rmin rmax ms@(V2 width height)
     | rmin <= 0 = error roomMinSizeMustBePositive
     | rmin > rmax = error $ roomMinIsLargerThanRoomMax rmin rmax -- No need to check if `rmax <= 0` as this ensures that `0 < rmin <= rmax`.
     | rmin > width = error $ roomMinSizeIsLargerThanRoomWidth rmin width
-    | rmin > height =
-        error $
-        "The room minimum size " ++
-        show rmin ++
-        " is larger than or equal to the map height " ++ show height ++ "."
+    | rmin > height = error $ roomMinSizeIsLargerThanRoomHeight rmin height
     | otherwise = Config nf mr rmin rmax ms
 
 numOfFloorsMustBePositive :: String
@@ -72,3 +68,9 @@ roomMinSizeIsLargerThanRoomWidth rmin width =
     "The room minimum size " ++
     show rmin ++
     " is larger than or equal to the map width " ++ show width ++ "."
+
+roomMinSizeIsLargerThanRoomHeight :: Int -> Int -> String
+roomMinSizeIsLargerThanRoomHeight rmin height =
+    "The room minimum size " ++
+    show rmin ++
+    " is larger than or equal to the map height " ++ show height ++ "."

--- a/src/Dungeon/Generate/Config.hs
+++ b/src/Dungeon/Generate/Config.hs
@@ -10,6 +10,8 @@ module Dungeon.Generate.Config
     , maxRoomMustBePositive
     , roomMinSizeMustBePositive
     , roomMinIsLargerThanRoomMax
+    , roomMinSizeIsLargerThanRoomWidth
+    , roomMinSizeIsLargerThanRoomHeight
     ) where
 
 import           Linear.V2 (V2 (V2))

--- a/src/Dungeon/Generate/Config.hs
+++ b/src/Dungeon/Generate/Config.hs
@@ -12,7 +12,7 @@ module Dungeon.Generate.Config
     , roomMinIsLargerThanRoomMax
     ) where
 
-import           Linear.V2 (V2)
+import           Linear.V2 (V2 (V2))
 
 data Config =
     Config
@@ -39,11 +39,16 @@ getMapSize :: Config -> V2 Int
 getMapSize = mapSize
 
 config :: Int -> Int -> Int -> Int -> V2 Int -> Config
-config nf mr rmin rmax ms
+config nf mr rmin rmax ms@(V2 width _)
     | nf <= 0 = error numOfFloorsMustBePositive
     | mr <= 0 = error maxRoomMustBePositive
     | rmin <= 0 = error roomMinSizeMustBePositive
     | rmin > rmax = error $ roomMinIsLargerThanRoomMax rmin rmax -- No need to check if `rmax <= 0` as this ensures that `0 < rmin <= rmax`.
+    | rmin > width =
+        error $
+        "The room minimum size " ++
+        show rmin ++
+        " is larger than or equal to the map width " ++ show width ++ "."
     | otherwise = Config nf mr rmin rmax ms
 
 numOfFloorsMustBePositive :: String

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -21,6 +21,7 @@ spec =
         testPanicIfMaxRoomsIsNotPositive
         testPanicIfRoomMinSizeIsNotPositive
         testPanicIfRoomMinSizeIsLargerThanRoomMaxSize
+        testPanicIfRoomMinSizeIsLargerThanMapSize
 
 testPanicIfNumOfFloorsIsNotPositive :: Spec
 testPanicIfNumOfFloorsIsNotPositive =
@@ -49,3 +50,10 @@ testPanicIfRoomMinSizeIsLargerThanRoomMaxSize =
     forAll generatePositiveBigSmallNumbers $ \(rmin, rmax) ->
         evaluate (config 1 1 rmin rmax (V2 100 100)) `shouldThrow`
         errorCall (roomMinIsLargerThanRoomMax rmin rmax)
+
+testPanicIfRoomMinSizeIsLargerThanMapSize :: Spec
+testPanicIfRoomMinSizeIsLargerThanMapSize =
+    it "panics if the given room minimum size is larger than the room size" $
+    evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
+    errorCall
+        "The room minimum size 5 is larger than or equal to the map width 4."

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -6,6 +6,8 @@ import           Control.Exception       (evaluate)
 import           Dungeon.Generate.Config (config, maxRoomMustBePositive,
                                           numOfFloorsMustBePositive,
                                           roomMinIsLargerThanRoomMax,
+                                          roomMinSizeIsLargerThanRoomHeight,
+                                          roomMinSizeIsLargerThanRoomWidth,
                                           roomMinSizeMustBePositive)
 import           Generator               (generateNonPositive,
                                           generatePositiveBigSmallNumbers)
@@ -55,8 +57,6 @@ testPanicIfRoomMinSizeIsLargerThanMapSize :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapSize =
     it "panics if the given room minimum size is larger than the room size" $ do
         evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
-            errorCall
-                "The room minimum size 5 is larger than or equal to the map width 4."
+            errorCall (roomMinSizeIsLargerThanRoomWidth 5 4)
         evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
-            errorCall
-                "The room minimum size 5 is larger than or equal to the map height 4."
+            errorCall (roomMinSizeIsLargerThanRoomHeight 5 4)

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -53,7 +53,10 @@ testPanicIfRoomMinSizeIsLargerThanRoomMaxSize =
 
 testPanicIfRoomMinSizeIsLargerThanMapSize :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapSize =
-    it "panics if the given room minimum size is larger than the room size" $
-    evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
-    errorCall
-        "The room minimum size 5 is larger than or equal to the map width 4."
+    it "panics if the given room minimum size is larger than the room size" $ do
+        evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
+            errorCall
+                "The room minimum size 5 is larger than or equal to the map width 4."
+        evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
+            errorCall
+                "The room minimum size 5 is larger than or equal to the map height 4."

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -23,7 +23,8 @@ spec =
         testPanicIfMaxRoomsIsNotPositive
         testPanicIfRoomMinSizeIsNotPositive
         testPanicIfRoomMinSizeIsLargerThanRoomMaxSize
-        testPanicIfRoomMinSizeIsLargerThanMapSize
+        testPanicIfRoomMinSizeIsLargerThanMapWidth
+        testPanicIfRoomMinSizeIsLargerThanMapHeight
 
 testPanicIfNumOfFloorsIsNotPositive :: Spec
 testPanicIfNumOfFloorsIsNotPositive =
@@ -53,10 +54,14 @@ testPanicIfRoomMinSizeIsLargerThanRoomMaxSize =
         evaluate (config 1 1 rmin rmax (V2 100 100)) `shouldThrow`
         errorCall (roomMinIsLargerThanRoomMax rmin rmax)
 
-testPanicIfRoomMinSizeIsLargerThanMapSize :: Spec
-testPanicIfRoomMinSizeIsLargerThanMapSize =
-    it "panics if the given room minimum size is larger than the room size" $ do
-        evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
-            errorCall (roomMinSizeIsLargerThanRoomWidth 5 4)
-        evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
-            errorCall (roomMinSizeIsLargerThanRoomHeight 5 4)
+testPanicIfRoomMinSizeIsLargerThanMapWidth :: Spec
+testPanicIfRoomMinSizeIsLargerThanMapWidth =
+    it "panics if the given room minimum size is larger than the room width" $
+    evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
+    errorCall (roomMinSizeIsLargerThanRoomWidth 5 4)
+
+testPanicIfRoomMinSizeIsLargerThanMapHeight :: Spec
+testPanicIfRoomMinSizeIsLargerThanMapHeight =
+    it "panics if the given room minimum size is larger than the room height" $
+    evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
+    errorCall (roomMinSizeIsLargerThanRoomHeight 5 4)

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -3,7 +3,7 @@ module Dungeon.Generate.ConfigSpec
     ) where
 
 import           Control.Exception       (evaluate)
-import           Dungeon.Generate.Config (Config, config, maxRoomMustBePositive,
+import           Dungeon.Generate.Config (config, maxRoomMustBePositive,
                                           numOfFloorsMustBePositive,
                                           roomMinIsLargerThanRoomMax,
                                           roomMinSizeIsLargerThanRoomHeight,
@@ -57,14 +57,11 @@ testPanicIfRoomMinSizeIsLargerThanRoomMaxSize =
 testPanicIfRoomMinSizeIsLargerThanMapWidth :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapWidth =
     it "panics if the given room minimum size is larger than the room width" $
-    evaluate (configFromMapSize $ V2 4 6) `shouldThrow`
+    evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
     errorCall (roomMinSizeIsLargerThanRoomWidth 5 4)
 
 testPanicIfRoomMinSizeIsLargerThanMapHeight :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapHeight =
     it "panics if the given room minimum size is larger than the room height" $
-    evaluate (configFromMapSize $ V2 6 4) `shouldThrow`
+    evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
     errorCall (roomMinSizeIsLargerThanRoomHeight 5 4)
-
-configFromMapSize :: V2 Int -> Config
-configFromMapSize = config 1 1 5 5

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -57,11 +57,17 @@ testPanicIfRoomMinSizeIsLargerThanRoomMaxSize =
 testPanicIfRoomMinSizeIsLargerThanMapWidth :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapWidth =
     it "panics if the given room minimum size is larger than the room width" $
-    evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
-    errorCall (roomMinSizeIsLargerThanRoomWidth 5 4)
+    evaluate (config 1 1 rmin 5 (V2 width 6)) `shouldThrow`
+    errorCall (roomMinSizeIsLargerThanRoomWidth rmin width)
+  where
+    rmin = 5
+    width = 4
 
 testPanicIfRoomMinSizeIsLargerThanMapHeight :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapHeight =
     it "panics if the given room minimum size is larger than the room height" $
-    evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
-    errorCall (roomMinSizeIsLargerThanRoomHeight 5 4)
+    evaluate (config 1 1 rmin 5 (V2 6 height)) `shouldThrow`
+    errorCall (roomMinSizeIsLargerThanRoomHeight rmin height)
+  where
+    rmin = 5
+    height = 4

--- a/tests/Dungeon/Generate/ConfigSpec.hs
+++ b/tests/Dungeon/Generate/ConfigSpec.hs
@@ -3,7 +3,7 @@ module Dungeon.Generate.ConfigSpec
     ) where
 
 import           Control.Exception       (evaluate)
-import           Dungeon.Generate.Config (config, maxRoomMustBePositive,
+import           Dungeon.Generate.Config (Config, config, maxRoomMustBePositive,
                                           numOfFloorsMustBePositive,
                                           roomMinIsLargerThanRoomMax,
                                           roomMinSizeIsLargerThanRoomHeight,
@@ -57,11 +57,14 @@ testPanicIfRoomMinSizeIsLargerThanRoomMaxSize =
 testPanicIfRoomMinSizeIsLargerThanMapWidth :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapWidth =
     it "panics if the given room minimum size is larger than the room width" $
-    evaluate (config 1 1 5 5 (V2 4 6)) `shouldThrow`
+    evaluate (configFromMapSize $ V2 4 6) `shouldThrow`
     errorCall (roomMinSizeIsLargerThanRoomWidth 5 4)
 
 testPanicIfRoomMinSizeIsLargerThanMapHeight :: Spec
 testPanicIfRoomMinSizeIsLargerThanMapHeight =
     it "panics if the given room minimum size is larger than the room height" $
-    evaluate (config 1 1 5 5 (V2 6 4)) `shouldThrow`
+    evaluate (configFromMapSize $ V2 6 4) `shouldThrow`
     errorCall (roomMinSizeIsLargerThanRoomHeight 5 4)
+
+configFromMapSize :: V2 Int -> Config
+configFromMapSize = config 1 1 5 5


### PR DESCRIPTION
- fix: forgot to reject "rmin > width"
- refactor: define `roomMinSizeIsLargerThanRoomWidth`
- fix: forgot to reject `rmin > height`
- refactor: define `roomMinSizeIsLargerThanRoomHeight`
- refactor: call the error message functions
- refactor: split a test
- refactor: define `configFromMapSize`
- Revert "refactor: define `configFromMapSize`"
- refactor: extract `rmin`, `width`, and `height`
