### PR TITLE
chore: derive `Show` for `CellMap`

### DIFF
--- a/tests/Gimlight/Dungeon/Map/CellSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/CellSpec.hs
@@ -1,27 +1,17 @@
-{-# LANGUAGE QuasiQuotes #-}
-
 module Gimlight.Dungeon.Map.CellSpec
     ( spec
     ) where
 
 import           Control.Lens              ((^.))
-import           Data.Array                (array)
-import           Data.String.QQ            (s)
-import           Gimlight.Dungeon.Map.Cell (TileIdentifierLayer (TileIdentifierLayer),
-                                            allWallTiles, cellMap,
-                                            tileIdentifierLayerAt, upper)
+import           Gimlight.Dungeon.Map.Cell (allWallTiles, tileIdentifierLayerAt,
+                                            upper)
 import           Gimlight.Dungeon.Map.Tile (wallTile)
-import           Gimlight.SetUp.CellMap    (initCellMap)
-import           Gimlight.SetUp.MapFile    (cellMapContainingMultipleFilesTile,
-                                            rectangleButNotSquareCellMap)
 import           Linear.V2                 (V2 (V2))
-import           Test.Hspec                (Spec, describe, it, shouldBe)
+import           Test.Hspec                (Spec, describe, it)
 import           Test.QuickCheck           (property)
 
 spec :: Spec
-spec = do
-    testAllWallTiles
-    testShowCellMap
+spec = testAllWallTiles
 
 testAllWallTiles :: Spec
 testAllWallTiles =
@@ -39,119 +29,3 @@ testAllWallTiles =
             False
             ((== Just wallTile) . (^. upper))
             (tileIdentifierLayerAt c cm)
-
-testShowCellMap :: Spec
-testShowCellMap =
-    describe "CellMap" $
-    it "show prints the detailed cell map information." $
-    mapM_ testFunc $ zip cellMaps expectations
-  where
-    testFunc (m, expected) = show m `shouldBe` expected
-    cellMaps =
-        [ cellMapContainingMultipleFilesTile
-        , initCellMap
-        , rectangleButNotSquareCellMap
-        , differentCellSize
-        ]
-    differentCellSize =
-        cellMap $
-        array
-            (V2 0 0, V2 0 0)
-            [ ( V2 0 0
-              , TileIdentifierLayer
-                    (Just ("foo.json", 10))
-                    (Just ("foo.json", 0)))
-            ]
-    expectations =
-        [ [s|
-Upper layer:
-+-----+-----+
-|     |     |
-+-----+-----+
-
-Lower layer:
-+-----+-----+
-|(0,0)|(1,1)|
-+-----+-----+
-
-Actors:
-+-----+-----+
-|     |     |
-+-----+-----+
-
-Tile files:
-0: tests/tiles/single.json
-1: tests/tiles/united.json|]
-        , [s|
-Upper layer:
-+------+------+------+
-|      |      |      |
-+------+------+------+
-|(0,1) |      |      |
-+------+------+------+
-|      |      |      |
-+------+------+------+
-|      |      |      |
-+------+------+------+
-
-Lower layer:
-+------+------+------+
-|      |      |      |
-+------+------+------+
-|      |      |      |
-+------+------+------+
-|      |      |      |
-+------+------+------+
-|      |      |      |
-+------+------+------+
-
-Actors:
-+------+------+------+
-|Player|Orc   |Orc   |
-+------+------+------+
-|      |      |Orc   |
-+------+------+------+
-|      |Orc   |      |
-+------+------+------+
-|Orc   |Orc   |      |
-+------+------+------+
-
-Tile files:
-0: dummy.json|]
-        , [s|
-Upper layer:
-+-----+-----+
-|     |     |
-+-----+-----+
-
-Lower layer:
-+-----+-----+
-|(0,0)|(0,0)|
-+-----+-----+
-
-Actors:
-+-----+-----+
-|     |     |
-+-----+-----+
-
-Tile files:
-0: tests/tiles/single.json|]
-        , [s|
-Upper layer:
-+------+
-|(0,10)|
-+------+
-
-Lower layer:
-+------+
-|(0,0) |
-+------+
-
-Actors:
-+------+
-|      |
-+------+
-
-Tile files:
-0: foo.json|]
-        ]


### PR DESCRIPTION
The current implementation is incomplete, and it is challenging to
complete it because as we add fields to `Cell` we have to modify the
`Show` implementation. So I have decided to remove it and just do
`deriving(Show)`.
