### PR TITLE
refactor: remove `initCellMap`

### DIFF
--- a/src/Gimlight/Actor.hs
+++ b/src/Gimlight/Actor.hs
@@ -53,7 +53,7 @@ import           Gimlight.GameStatus.Talking.Part (TalkingPart)
 import           Gimlight.IndexGenerator          (Index, IndexGenerator,
                                                    generate)
 import           Gimlight.Inventory               (Inventory, addItem,
-                                                   inventory)
+                                                   inventory, maxSlot)
 import qualified Gimlight.Inventory               as I
 import           Gimlight.Item                    (Item)
 import           Gimlight.Item.Armor              (Armor)
@@ -108,7 +108,7 @@ actor id' st ak talkMessage' walkingImagePath' standingImagePath' = do
             , _walkingImagePath = walkingImagePath'
             , _standingImagePath = standingImagePath'
             , _actorKind = ak
-            , _inventoryItems = inventory 5
+            , _inventoryItems = inventory maxSlot
             , _target = Nothing
             , _weapon = Nothing
             , _armor = Nothing

--- a/src/Gimlight/Inventory.hs
+++ b/src/Gimlight/Inventory.hs
@@ -7,6 +7,7 @@ module Gimlight.Inventory
     , addItem
     , getItems
     , removeNthItem
+    , maxSlot
     ) where
 
 import           Control.Lens           (makeLenses, (%~), (&), (.~), (^.))
@@ -42,3 +43,6 @@ removeNthItem n e =
   where
     newItems = take n (e ^. items) ++ drop (n + 1) (e ^. items)
     removedItem = (e ^. items) !! n
+
+maxSlot :: Int
+maxSlot = 5

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -2,7 +2,7 @@ module Gimlight.Action.PickUpSpec
     ( spec
     ) where
 
-import           Control.Lens                ((%~), (&))
+import           Control.Lens                (over, (%~), (&))
 import           Control.Monad.State         (StateT (runStateT), evalState,
                                               execStateT)
 import           Control.Monad.Writer        (writer)
@@ -13,7 +13,7 @@ import           Data.OpenUnion              (liftUnion)
 import           Gimlight.Action             (ActionResult (ActionResult, killed, newCellMap, status),
                                               ActionStatus (Failed, Ok))
 import           Gimlight.Action.PickUp      (pickUpAction)
-import           Gimlight.Actor              (inventoryItems, player)
+import           Gimlight.Actor              (Actor, inventoryItems, player)
 import           Gimlight.Coord              (Coord)
 import           Gimlight.Dungeon.Map.Cell   (CellMap,
                                               TileIdLayer (TileIdLayer),
@@ -24,6 +24,7 @@ import           Gimlight.IndexGenerator     (generator)
 import           Gimlight.Inventory          (addItem, maxSlot)
 import           Gimlight.Item               (getName)
 import           Gimlight.Item.Defined       (herb)
+import           Gimlight.Item.SomeItem      (SomeItem)
 import qualified Gimlight.Localization.Texts as T
 import           Gimlight.SetUp.CellMap      (initTileCollection)
 import           Linear                      (V2 (V2))
@@ -38,8 +39,7 @@ spec = do
 testPickUpSuccess :: Spec
 testPickUpSuccess =
     it "returns a Ok result if there is an item at the actor's foot, and player's inventory is not full." $
-    result `shouldBe`
-    expected
+    result `shouldBe` expected
   where
     result = pickUpAction playerPos initTileCollection cm'
     expected = writer (expectedResult, expectedLog)
@@ -47,7 +47,8 @@ testPickUpSuccess =
         ActionResult
             {status = Ok, newCellMap = cellMapAfterPickingUp, killed = []}
     cellMapAfterPickingUp =
-        fromRight' $ flip execStateT cm' $ do
+        fromRight' $
+        flip execStateT cm' $ do
             _ <- removeItemAt playerPos
             _ <- removeActorAt playerPos
             locateActorAt initTileCollection actorWithItem playerPos
@@ -56,42 +57,45 @@ testPickUpSuccess =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
             (fromRight' $ flip runStateT cm' $ removeActorAt playerPos)
     cm' =
-        fromRight' $ flip execStateT cellMapWithPlayer $
+        fromRight' $
+        flip execStateT cellMapWithPlayer $
         locateItemAt initTileCollection (liftUnion herb) playerPos
 
 testPickUpVoid :: Spec
 testPickUpVoid =
     it "returns a Failed result if there is no item at the actor's foot." $
-    result `shouldBe`
-    expected
+    result `shouldBe` expected
   where
     result = pickUpAction playerPos initTileCollection cellMapWithPlayer
     expected = writer (failedResult cellMapWithPlayer, [T.youGotNothing])
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =
-    it "returns a Failed result if the actor's inventory is full." $ result `shouldBe`
-    expected
+    it "returns a Failed result if the actor's inventory is full." $
+    result `shouldBe` expected
   where
     result = pickUpAction playerPos initTileCollection cm
     expected = writer (failedResult cm, [T.bagIsFull])
     cm =
-        fromRight' $ flip execStateT emptyCellMap $ do
+        fromRight' $
+        flip execStateT emptyCellMap $ do
             locateItemAt initTileCollection (liftUnion herb) playerPos
             locateActorAt
                 initTileCollection
-                (iterate
-                     (inventoryItems %~ fromJust . addItem (liftUnion herb))
-                     (evalState player generator) !!
-                 maxSlot)
+                (addItems items (evalState player generator))
                 playerPos
+    items = replicate maxSlot $ liftUnion herb
+
+addItems :: [SomeItem] -> Actor -> Actor
+addItems xs a = foldr (\x -> over inventoryItems (fromJust . addItem x)) a xs
 
 failedResult :: CellMap -> ActionResult
 failedResult cm = ActionResult {status = Failed, newCellMap = cm, killed = []}
 
 cellMapWithPlayer :: CellMap
 cellMapWithPlayer =
-    fromRight' $ flip execStateT emptyCellMap $
+    fromRight' $
+    flip execStateT emptyCellMap $
     locateActorAt initTileCollection (evalState player generator) playerPos
 
 emptyCellMap :: CellMap

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -25,8 +25,7 @@ import           Gimlight.Inventory          (addItem, maxSlot)
 import           Gimlight.Item               (getName)
 import           Gimlight.Item.Defined       (herb)
 import qualified Gimlight.Localization.Texts as T
-import           Gimlight.SetUp.CellMap      (initTileCollection,
-                                              orcWithFullItemsPosition)
+import           Gimlight.SetUp.CellMap      (initTileCollection)
 import           Linear                      (V2 (V2))
 import           Test.Hspec                  (Spec, it, shouldBe)
 
@@ -78,7 +77,7 @@ testPickUpWhenInventoryIsFull =
     it "returns a Failed result if the actor's inventory is full." $ result `shouldBe`
     expected
   where
-    result = pickUpAction orcWithFullItemsPosition initTileCollection cm
+    result = pickUpAction playerPos initTileCollection cm
     expected = writer (expectedResult, expectedLog)
     expectedResult =
         ActionResult {status = Failed, newCellMap = cm, killed = []}

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -3,25 +3,31 @@ module Gimlight.Action.PickUpSpec
     ) where
 
 import           Control.Lens                ((%~), (&))
-import           Control.Monad.State         (StateT (runStateT), execStateT)
+import           Control.Monad.State         (StateT (runStateT), evalState,
+                                              execStateT)
 import           Control.Monad.Writer        (writer)
+import           Data.Array                  (array)
+import           Data.Either.Combinators     (fromRight')
 import           Data.Maybe                  (fromJust)
 import           Data.OpenUnion              (liftUnion)
 import           Gimlight.Action             (ActionResult (ActionResult, killed, newCellMap, status),
                                               ActionStatus (Failed, Ok))
 import           Gimlight.Action.PickUp      (pickUpAction)
-import           Gimlight.Actor              (inventoryItems)
+import           Gimlight.Actor              (inventoryItems, player)
 import           Gimlight.Data.Either        (expectRight)
-import           Gimlight.Dungeon.Map.Cell   (locateActorAt, removeActorAt,
+import           Gimlight.Dungeon.Map.Cell   (TileIdLayer (TileIdLayer),
+                                              cellMap, locateActorAt,
+                                              locateItemAt, removeActorAt,
                                               removeItemAt)
+import           Gimlight.IndexGenerator     (generator)
 import           Gimlight.Inventory          (addItem)
 import           Gimlight.Item               (getName)
 import           Gimlight.Item.Defined       (herb)
 import qualified Gimlight.Localization.Texts as T
 import           Gimlight.SetUp.CellMap      (initCellMap, initTileCollection,
                                               orcWithFullItemsPosition,
-                                              orcWithoutItemsPosition,
-                                              playerPosition)
+                                              orcWithoutItemsPosition)
+import           Linear                      (V2 (V2))
 import           Test.Hspec                  (Spec, it, shouldBe)
 
 spec :: Spec
@@ -35,23 +41,33 @@ testPickUpSuccess =
     it "returns a Ok result if there is an item at the actor's foot, and player's inventory is not full." $
     result `shouldBe` expected
   where
-    result = pickUpAction playerPosition initTileCollection initCellMap
+    result = pickUpAction (V2 0 0) initTileCollection cm'
     expected = writer (expectedResult, expectedLog)
     expectedResult =
         ActionResult
             {status = Ok, newCellMap = cellMapAfterPickingUp, killed = []}
     cellMapAfterPickingUp =
         expectRight "Failed to pick up." $
-        flip execStateT initCellMap $ do
-            _ <- removeItemAt playerPosition
-            _ <- removeActorAt playerPosition
-            locateActorAt initTileCollection actorWithItem playerPosition
+        flip execStateT cm' $ do
+            _ <- removeItemAt (V2 0 0)
+            _ <- removeActorAt (V2 0 0)
+            locateActorAt initTileCollection actorWithItem (V2 0 0)
     expectedLog = [T.youGotItem $ getName herb]
     actorWithItem =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
             (expectRight
                  "Failed to add an item."
-                 (flip runStateT initCellMap $ removeActorAt playerPosition))
+                 (flip runStateT cm' $ removeActorAt (V2 0 0)))
+    cm' =
+        fromRight' $
+        flip execStateT cm $ do
+            locateActorAt
+                initTileCollection
+                (evalState player generator)
+                (V2 0 0)
+            locateItemAt initTileCollection (liftUnion herb) (V2 0 0)
+    cm =
+        cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
 
 testPickUpVoid :: Spec
 testPickUpVoid =

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -60,12 +60,8 @@ testPickUpSuccess =
                  (flip runStateT cm' $ removeActorAt playerPos))
     cm' =
         fromRight' $
-        flip execStateT emptyCellMap $ do
-            locateActorAt
-                initTileCollection
-                (evalState player generator)
-                playerPos
-            locateItemAt initTileCollection (liftUnion herb) playerPos
+        flip execStateT cellMapWithPlayer $
+        locateItemAt initTileCollection (liftUnion herb) playerPos
     playerPos = V2 0 0
 
 testPickUpVoid :: Spec
@@ -78,10 +74,7 @@ testPickUpVoid =
     expectedResult =
         ActionResult {status = Failed, newCellMap = cm', killed = []}
     expectedLog = [T.youGotNothing]
-    cm' =
-        fromRight' $
-        flip execStateT emptyCellMap $
-        locateActorAt initTileCollection (evalState player generator) playerPos
+    cm' = cellMapWithPlayer
     playerPos = V2 0 0
 
 testPickUpWhenInventoryIsFull :: Spec
@@ -95,6 +88,12 @@ testPickUpWhenInventoryIsFull =
     expectedResult =
         ActionResult {status = Failed, newCellMap = initCellMap, killed = []}
     expectedLog = [T.bagIsFull]
+
+cellMapWithPlayer :: CellMap
+cellMapWithPlayer =
+    fromRight' $
+    flip execStateT emptyCellMap $
+    locateActorAt initTileCollection (evalState player generator) (V2 0 0)
 
 emptyCellMap :: CellMap
 emptyCellMap =

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -67,9 +67,7 @@ testPickUpVoid =
   where
     result = pickUpAction playerPos initTileCollection cellMapWithPlayer
     expected = writer (expectedResult, expectedLog)
-    expectedResult =
-        ActionResult
-            {status = Failed, newCellMap = cellMapWithPlayer, killed = []}
+    expectedResult = failedResult cellMapWithPlayer
     expectedLog = [T.youGotNothing]
 
 testPickUpWhenInventoryIsFull :: Spec
@@ -79,8 +77,7 @@ testPickUpWhenInventoryIsFull =
   where
     result = pickUpAction playerPos initTileCollection cm
     expected = writer (expectedResult, expectedLog)
-    expectedResult =
-        ActionResult {status = Failed, newCellMap = cm, killed = []}
+    expectedResult = failedResult cm
     expectedLog = [T.bagIsFull]
     cm =
         fromRight' $ flip execStateT emptyCellMap $ do
@@ -92,6 +89,9 @@ testPickUpWhenInventoryIsFull =
                      (evalState player generator) !!
                  maxSlot)
                 playerPos
+
+failedResult :: CellMap -> ActionResult
+failedResult cm = ActionResult {status = Failed, newCellMap = cm, killed = []}
 
 cellMapWithPlayer :: CellMap
 cellMapWithPlayer =

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -25,8 +25,7 @@ import           Gimlight.Item               (getName)
 import           Gimlight.Item.Defined       (herb)
 import qualified Gimlight.Localization.Texts as T
 import           Gimlight.SetUp.CellMap      (initCellMap, initTileCollection,
-                                              orcWithFullItemsPosition,
-                                              orcWithoutItemsPosition)
+                                              orcWithFullItemsPosition)
 import           Linear                      (V2 (V2))
 import           Test.Hspec                  (Spec, it, shouldBe)
 
@@ -75,11 +74,18 @@ testPickUpVoid =
     it "returns a Failed result if there is no item at the actor's foot." $
     result `shouldBe` expected
   where
-    result = pickUpAction orcWithoutItemsPosition initTileCollection initCellMap
+    result = pickUpAction playerPos initTileCollection cm'
     expected = writer (expectedResult, expectedLog)
     expectedResult =
-        ActionResult {status = Failed, newCellMap = initCellMap, killed = []}
+        ActionResult {status = Failed, newCellMap = cm', killed = []}
     expectedLog = [T.youGotNothing]
+    cm' =
+        fromRight' $
+        flip execStateT cm $
+        locateActorAt initTileCollection (evalState player generator) playerPos
+    cm =
+        cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
+    playerPos = V2 0 0
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -62,11 +62,10 @@ testPickUpSuccess =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
             (fromRight' $ flip runStateT cm' $ removeActorAt playerPos)
     cm' =
-        locateItemsActors
+        cellMapWith
             [ (playerPos, liftUnion (liftUnion herb :: SomeItem))
             , (playerPos, liftUnion player)
             ]
-            emptyCellMap
 
 testPickUpVoid :: Spec
 testPickUpVoid =
@@ -75,7 +74,7 @@ testPickUpVoid =
   where
     result = pickUpAction playerPos initTileCollection cm
     expected = writer (failedResult cm, [T.youGotNothing])
-    cm = locateItemsActors [(playerPos, liftUnion player)] emptyCellMap
+    cm = cellMapWith [(playerPos, liftUnion player)]
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =
@@ -85,12 +84,14 @@ testPickUpWhenInventoryIsFull =
     result = pickUpAction playerPos initTileCollection cm
     expected = writer (failedResult cm, [T.bagIsFull])
     cm =
-        locateItemsActors
+        cellMapWith
             [ (playerPos, liftUnion (liftUnion herb :: SomeItem))
             , (playerPos, liftUnion $ addItems items player)
             ]
-            emptyCellMap
     items = replicate maxSlot $ liftUnion herb
+
+cellMapWith :: [(Coord, Union '[ Actor, SomeItem])] -> CellMap
+cellMapWith xs = locateItemsActors xs emptyCellMap
 
 locateItemsActors :: [(Coord, Union '[ Actor, SomeItem])] -> CellMap -> CellMap
 locateItemsActors xs cm = foldl helper cm xs

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -15,7 +15,6 @@ import           Gimlight.Action             (ActionResult (ActionResult, killed
 import           Gimlight.Action.PickUp      (pickUpAction)
 import           Gimlight.Actor              (inventoryItems, player)
 import           Gimlight.Coord              (Coord)
-import           Gimlight.Data.Either        (expectRight)
 import           Gimlight.Dungeon.Map.Cell   (CellMap,
                                               TileIdLayer (TileIdLayer),
                                               cellMap, locateActorAt,
@@ -48,7 +47,7 @@ testPickUpSuccess =
         ActionResult
             {status = Ok, newCellMap = cellMapAfterPickingUp, killed = []}
     cellMapAfterPickingUp =
-        expectRight "Failed to pick up." $
+        fromRight' $
         flip execStateT cm' $ do
             _ <- removeItemAt playerPos
             _ <- removeActorAt playerPos
@@ -56,9 +55,7 @@ testPickUpSuccess =
     expectedLog = [T.youGotItem $ getName herb]
     actorWithItem =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
-            (expectRight
-                 "Failed to add an item."
-                 (flip runStateT cm' $ removeActorAt playerPos))
+            (fromRight' $ flip runStateT cm' $ removeActorAt playerPos)
     cm' =
         fromRight' $
         flip execStateT cellMapWithPlayer $

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -69,12 +69,12 @@ testPickUpVoid =
     it "returns a Failed result if there is no item at the actor's foot." $
     result `shouldBe` expected
   where
-    result = pickUpAction playerPos initTileCollection cm'
+    result = pickUpAction playerPos initTileCollection cellMapWithPlayer
     expected = writer (expectedResult, expectedLog)
     expectedResult =
-        ActionResult {status = Failed, newCellMap = cm', killed = []}
+        ActionResult
+            {status = Failed, newCellMap = cellMapWithPlayer, killed = []}
     expectedLog = [T.youGotNothing]
-    cm' = cellMapWithPlayer
     playerPos = V2 0 0
 
 testPickUpWhenInventoryIsFull :: Spec

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -13,7 +13,8 @@ import           Data.OpenUnion              (liftUnion)
 import           Gimlight.Action             (ActionResult (ActionResult, killed, newCellMap, status),
                                               ActionStatus (Failed, Ok))
 import           Gimlight.Action.PickUp      (pickUpAction)
-import           Gimlight.Actor              (Actor, inventoryItems, player)
+import           Gimlight.Actor              (Actor, inventoryItems)
+import qualified Gimlight.Actor              as A
 import           Gimlight.Coord              (Coord)
 import           Gimlight.Dungeon.Map.Cell   (CellMap,
                                               TileIdLayer (TileIdLayer),
@@ -80,10 +81,7 @@ testPickUpWhenInventoryIsFull =
         fromRight' $
         flip execStateT emptyCellMap $ do
             locateItemAt initTileCollection (liftUnion herb) playerPos
-            locateActorAt
-                initTileCollection
-                (addItems items (evalState player generator))
-                playerPos
+            locateActorAt initTileCollection (addItems items player) playerPos
     items = replicate maxSlot $ liftUnion herb
 
 addItems :: [SomeItem] -> Actor -> Actor
@@ -96,11 +94,14 @@ cellMapWithPlayer :: CellMap
 cellMapWithPlayer =
     fromRight' $
     flip execStateT emptyCellMap $
-    locateActorAt initTileCollection (evalState player generator) playerPos
+    locateActorAt initTileCollection player playerPos
 
 emptyCellMap :: CellMap
 emptyCellMap =
     cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
+
+player :: Actor
+player = evalState A.player generator
 
 playerPos :: Coord
 playerPos = V2 0 0

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -41,7 +41,7 @@ testPickUpSuccess =
     it "returns a Ok result if there is an item at the actor's foot, and player's inventory is not full." $
     result `shouldBe` expected
   where
-    result = pickUpAction (V2 0 0) initTileCollection cm'
+    result = pickUpAction playerPos initTileCollection cm'
     expected = writer (expectedResult, expectedLog)
     expectedResult =
         ActionResult
@@ -49,25 +49,26 @@ testPickUpSuccess =
     cellMapAfterPickingUp =
         expectRight "Failed to pick up." $
         flip execStateT cm' $ do
-            _ <- removeItemAt (V2 0 0)
-            _ <- removeActorAt (V2 0 0)
-            locateActorAt initTileCollection actorWithItem (V2 0 0)
+            _ <- removeItemAt playerPos
+            _ <- removeActorAt playerPos
+            locateActorAt initTileCollection actorWithItem playerPos
     expectedLog = [T.youGotItem $ getName herb]
     actorWithItem =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
             (expectRight
                  "Failed to add an item."
-                 (flip runStateT cm' $ removeActorAt (V2 0 0)))
+                 (flip runStateT cm' $ removeActorAt playerPos))
     cm' =
         fromRight' $
         flip execStateT cm $ do
             locateActorAt
                 initTileCollection
                 (evalState player generator)
-                (V2 0 0)
-            locateItemAt initTileCollection (liftUnion herb) (V2 0 0)
+                playerPos
+            locateItemAt initTileCollection (liftUnion herb) playerPos
     cm =
         cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
+    playerPos = V2 0 0
 
 testPickUpVoid :: Spec
 testPickUpVoid =

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -14,6 +14,7 @@ import           Gimlight.Action             (ActionResult (ActionResult, killed
                                               ActionStatus (Failed, Ok))
 import           Gimlight.Action.PickUp      (pickUpAction)
 import           Gimlight.Actor              (inventoryItems, player)
+import           Gimlight.Coord              (Coord)
 import           Gimlight.Data.Either        (expectRight)
 import           Gimlight.Dungeon.Map.Cell   (CellMap,
                                               TileIdLayer (TileIdLayer),
@@ -62,7 +63,6 @@ testPickUpSuccess =
         fromRight' $
         flip execStateT cellMapWithPlayer $
         locateItemAt initTileCollection (liftUnion herb) playerPos
-    playerPos = V2 0 0
 
 testPickUpVoid :: Spec
 testPickUpVoid =
@@ -75,7 +75,6 @@ testPickUpVoid =
         ActionResult
             {status = Failed, newCellMap = cellMapWithPlayer, killed = []}
     expectedLog = [T.youGotNothing]
-    playerPos = V2 0 0
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =
@@ -93,8 +92,11 @@ cellMapWithPlayer :: CellMap
 cellMapWithPlayer =
     fromRight' $
     flip execStateT emptyCellMap $
-    locateActorAt initTileCollection (evalState player generator) (V2 0 0)
+    locateActorAt initTileCollection (evalState player generator) playerPos
 
 emptyCellMap :: CellMap
 emptyCellMap =
     cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
+
+playerPos :: Coord
+playerPos = V2 0 0

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -25,7 +25,7 @@ import           Gimlight.Inventory          (addItem)
 import           Gimlight.Item               (getName)
 import           Gimlight.Item.Defined       (herb)
 import qualified Gimlight.Localization.Texts as T
-import           Gimlight.SetUp.CellMap      (initCellMap, initTileCollection,
+import           Gimlight.SetUp.CellMap      (initTileCollection,
                                               orcWithFullItemsPosition)
 import           Linear                      (V2 (V2))
 import           Test.Hspec                  (Spec, it, shouldBe)
@@ -39,7 +39,8 @@ spec = do
 testPickUpSuccess :: Spec
 testPickUpSuccess =
     it "returns a Ok result if there is an item at the actor's foot, and player's inventory is not full." $
-    result `shouldBe` expected
+    result `shouldBe`
+    expected
   where
     result = pickUpAction playerPos initTileCollection cm'
     expected = writer (expectedResult, expectedLog)
@@ -47,8 +48,7 @@ testPickUpSuccess =
         ActionResult
             {status = Ok, newCellMap = cellMapAfterPickingUp, killed = []}
     cellMapAfterPickingUp =
-        fromRight' $
-        flip execStateT cm' $ do
+        fromRight' $ flip execStateT cm' $ do
             _ <- removeItemAt playerPos
             _ <- removeActorAt playerPos
             locateActorAt initTileCollection actorWithItem playerPos
@@ -57,14 +57,14 @@ testPickUpSuccess =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
             (fromRight' $ flip runStateT cm' $ removeActorAt playerPos)
     cm' =
-        fromRight' $
-        flip execStateT cellMapWithPlayer $
+        fromRight' $ flip execStateT cellMapWithPlayer $
         locateItemAt initTileCollection (liftUnion herb) playerPos
 
 testPickUpVoid :: Spec
 testPickUpVoid =
     it "returns a Failed result if there is no item at the actor's foot." $
-    result `shouldBe` expected
+    result `shouldBe`
+    expected
   where
     result = pickUpAction playerPos initTileCollection cellMapWithPlayer
     expected = writer (expectedResult, expectedLog)
@@ -75,20 +75,28 @@ testPickUpVoid =
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =
-    it "returns a Failed result if the actor's inventory is full." $
-    result `shouldBe` expected
+    it "returns a Failed result if the actor's inventory is full." $ result `shouldBe`
+    expected
   where
-    result =
-        pickUpAction orcWithFullItemsPosition initTileCollection initCellMap
+    result = pickUpAction orcWithFullItemsPosition initTileCollection cm
     expected = writer (expectedResult, expectedLog)
     expectedResult =
-        ActionResult {status = Failed, newCellMap = initCellMap, killed = []}
+        ActionResult {status = Failed, newCellMap = cm, killed = []}
     expectedLog = [T.bagIsFull]
+    cm =
+        fromRight' $ flip execStateT emptyCellMap $ do
+            locateItemAt initTileCollection (liftUnion herb) playerPos
+            locateActorAt
+                initTileCollection
+                (iterate
+                     (inventoryItems %~ fromJust . addItem (liftUnion herb))
+                     (evalState player generator) !!
+                 5)
+                playerPos
 
 cellMapWithPlayer :: CellMap
 cellMapWithPlayer =
-    fromRight' $
-    flip execStateT emptyCellMap $
+    fromRight' $ flip execStateT emptyCellMap $
     locateActorAt initTileCollection (evalState player generator) playerPos
 
 emptyCellMap :: CellMap

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -66,9 +66,7 @@ testPickUpVoid =
     expected
   where
     result = pickUpAction playerPos initTileCollection cellMapWithPlayer
-    expected = writer (expectedResult, expectedLog)
-    expectedResult = failedResult cellMapWithPlayer
-    expectedLog = [T.youGotNothing]
+    expected = writer (failedResult cellMapWithPlayer, [T.youGotNothing])
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =
@@ -76,9 +74,7 @@ testPickUpWhenInventoryIsFull =
     expected
   where
     result = pickUpAction playerPos initTileCollection cm
-    expected = writer (expectedResult, expectedLog)
-    expectedResult = failedResult cm
-    expectedLog = [T.bagIsFull]
+    expected = writer (failedResult cm, [T.bagIsFull])
     cm =
         fromRight' $ flip execStateT emptyCellMap $ do
             locateItemAt initTileCollection (liftUnion herb) playerPos

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -15,7 +15,8 @@ import           Gimlight.Action             (ActionResult (ActionResult, killed
 import           Gimlight.Action.PickUp      (pickUpAction)
 import           Gimlight.Actor              (inventoryItems, player)
 import           Gimlight.Data.Either        (expectRight)
-import           Gimlight.Dungeon.Map.Cell   (TileIdLayer (TileIdLayer),
+import           Gimlight.Dungeon.Map.Cell   (CellMap,
+                                              TileIdLayer (TileIdLayer),
                                               cellMap, locateActorAt,
                                               locateItemAt, removeActorAt,
                                               removeItemAt)
@@ -59,14 +60,12 @@ testPickUpSuccess =
                  (flip runStateT cm' $ removeActorAt playerPos))
     cm' =
         fromRight' $
-        flip execStateT cm $ do
+        flip execStateT emptyCellMap $ do
             locateActorAt
                 initTileCollection
                 (evalState player generator)
                 playerPos
             locateItemAt initTileCollection (liftUnion herb) playerPos
-    cm =
-        cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
     playerPos = V2 0 0
 
 testPickUpVoid :: Spec
@@ -81,10 +80,8 @@ testPickUpVoid =
     expectedLog = [T.youGotNothing]
     cm' =
         fromRight' $
-        flip execStateT cm $
+        flip execStateT emptyCellMap $
         locateActorAt initTileCollection (evalState player generator) playerPos
-    cm =
-        cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]
     playerPos = V2 0 0
 
 testPickUpWhenInventoryIsFull :: Spec
@@ -98,3 +95,7 @@ testPickUpWhenInventoryIsFull =
     expectedResult =
         ActionResult {status = Failed, newCellMap = initCellMap, killed = []}
     expectedLog = [T.bagIsFull]
+
+emptyCellMap :: CellMap
+emptyCellMap =
+    cellMap $ array (V2 0 0, V2 0 0) [(V2 0 0, TileIdLayer Nothing Nothing)]

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -21,7 +21,7 @@ import           Gimlight.Dungeon.Map.Cell   (CellMap,
                                               locateItemAt, removeActorAt,
                                               removeItemAt)
 import           Gimlight.IndexGenerator     (generator)
-import           Gimlight.Inventory          (addItem)
+import           Gimlight.Inventory          (addItem, maxSlot)
 import           Gimlight.Item               (getName)
 import           Gimlight.Item.Defined       (herb)
 import qualified Gimlight.Localization.Texts as T
@@ -91,7 +91,7 @@ testPickUpWhenInventoryIsFull =
                 (iterate
                      (inventoryItems %~ fromJust . addItem (liftUnion herb))
                      (evalState player generator) !!
-                 5)
+                 maxSlot)
                 playerPos
 
 cellMapWithPlayer :: CellMap

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -46,22 +46,22 @@ testPickUpSuccess =
     it "returns a Ok result if there is an item at the actor's foot, and player's inventory is not full." $
     result `shouldBe` expected
   where
-    result = pickUpAction playerPos initTileCollection cm'
+    result = pickUpAction playerPos initTileCollection cm
     expected = writer (expectedResult, expectedLog)
     expectedResult =
         ActionResult
             {status = Ok, newCellMap = cellMapAfterPickingUp, killed = []}
     cellMapAfterPickingUp =
         fromRight' $
-        flip execStateT cm' $ do
+        flip execStateT cm $ do
             _ <- removeItemAt playerPos
             _ <- removeActorAt playerPos
             locateActorAt initTileCollection actorWithItem playerPos
     expectedLog = [T.youGotItem $ getName herb]
     actorWithItem =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
-            (fromRight' $ flip runStateT cm' $ removeActorAt playerPos)
-    cm' =
+            (fromRight' $ flip runStateT cm $ removeActorAt playerPos)
+    cm =
         cellMapWith
             [ (playerPos, liftUnion (liftUnion herb :: SomeItem))
             , (playerPos, liftUnion player)

--- a/tests/Gimlight/Action/PickUpSpec.hs
+++ b/tests/Gimlight/Action/PickUpSpec.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs     #-}
+
 module Gimlight.Action.PickUpSpec
     ( spec
     ) where
@@ -9,7 +12,8 @@ import           Control.Monad.Writer        (writer)
 import           Data.Array                  (array)
 import           Data.Either.Combinators     (fromRight')
 import           Data.Maybe                  (fromJust)
-import           Data.OpenUnion              (liftUnion)
+import           Data.OpenUnion              (Union, liftUnion, typesExhausted,
+                                              (@>))
 import           Gimlight.Action             (ActionResult (ActionResult, killed, newCellMap, status),
                                               ActionStatus (Failed, Ok))
 import           Gimlight.Action.PickUp      (pickUpAction)
@@ -58,17 +62,20 @@ testPickUpSuccess =
         (\(x, _) -> x & inventoryItems %~ (fromJust . addItem (liftUnion herb)))
             (fromRight' $ flip runStateT cm' $ removeActorAt playerPos)
     cm' =
-        fromRight' $
-        flip execStateT cellMapWithPlayer $
-        locateItemAt initTileCollection (liftUnion herb) playerPos
+        locateItemsActors
+            [ (playerPos, liftUnion (liftUnion herb :: SomeItem))
+            , (playerPos, liftUnion player)
+            ]
+            emptyCellMap
 
 testPickUpVoid :: Spec
 testPickUpVoid =
     it "returns a Failed result if there is no item at the actor's foot." $
     result `shouldBe` expected
   where
-    result = pickUpAction playerPos initTileCollection cellMapWithPlayer
-    expected = writer (failedResult cellMapWithPlayer, [T.youGotNothing])
+    result = pickUpAction playerPos initTileCollection cm
+    expected = writer (failedResult cm, [T.youGotNothing])
+    cm = locateItemsActors [(playerPos, liftUnion player)] emptyCellMap
 
 testPickUpWhenInventoryIsFull :: Spec
 testPickUpWhenInventoryIsFull =
@@ -78,23 +85,28 @@ testPickUpWhenInventoryIsFull =
     result = pickUpAction playerPos initTileCollection cm
     expected = writer (failedResult cm, [T.bagIsFull])
     cm =
-        fromRight' $
-        flip execStateT emptyCellMap $ do
-            locateItemAt initTileCollection (liftUnion herb) playerPos
-            locateActorAt initTileCollection (addItems items player) playerPos
+        locateItemsActors
+            [ (playerPos, liftUnion (liftUnion herb :: SomeItem))
+            , (playerPos, liftUnion $ addItems items player)
+            ]
+            emptyCellMap
     items = replicate maxSlot $ liftUnion herb
+
+locateItemsActors :: [(Coord, Union '[ Actor, SomeItem])] -> CellMap -> CellMap
+locateItemsActors xs cm = foldl helper cm xs
+  where
+    helper ncm (pos, x) =
+        fromRight' $ (itemFunc ncm pos @> actorFunc ncm pos @> typesExhausted) x
+    actorFunc ncm pos x =
+        flip execStateT ncm $ locateActorAt initTileCollection x pos
+    itemFunc ncm pos x =
+        flip execStateT ncm $ locateItemAt initTileCollection x pos
 
 addItems :: [SomeItem] -> Actor -> Actor
 addItems xs a = foldr (\x -> over inventoryItems (fromJust . addItem x)) a xs
 
 failedResult :: CellMap -> ActionResult
 failedResult cm = ActionResult {status = Failed, newCellMap = cm, killed = []}
-
-cellMapWithPlayer :: CellMap
-cellMapWithPlayer =
-    fromRight' $
-    flip execStateT emptyCellMap $
-    locateActorAt initTileCollection player playerPos
 
 emptyCellMap :: CellMap
 emptyCellMap =


### PR DESCRIPTION
It becomes big, and we're no longer able to handle it.
