### PR TITLE
refactor: do not integrate type definitions

### DIFF
--- a/src/Gimlight/UI/Draw/Config.hs
+++ b/src/Gimlight/UI/Draw/Config.hs
@@ -8,20 +8,23 @@ module Gimlight.UI.Draw.Config
     , windowHeight
     ) where
 
-tileWidth, tileHeight :: Int
+tileWidth :: Int
 tileWidth = 48
 
+tileHeight :: Int
 tileHeight = 48
 
-tileColumns, tileRows :: Int
+tileColumns :: Int
 tileColumns = 23
 
+tileRows :: Int
 tileRows = 13
 
 logRows :: Int
 logRows = 5
 
-windowWidth, windowHeight :: Int
+windowWidth :: Int
 windowWidth = 1280
 
+windowHeight :: Int
 windowHeight = 720


### PR DESCRIPTION
The formatter automatically inserts empty lines into each function
definition. Adding the type declarations above the each definition is
better.
