### PR TITLE
ci: install packages separately

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,8 +36,8 @@ jobs:
         sudo apt update
         sudo apt install libsdl2-dev libglew-dev moreutils
         cabal update -j
-        cabal install weeder hlint stylish-haskell -j -z
-        stack install hindent
+        cabal install weeder hlint -j -z
+        stack install hindent stylish-haskell
 
     - name: Generate `cabal.project.local`
       run: "echo \"package * \n  ghc-options: -fwrite-ide-info\" > cabal.project.local"
@@ -58,4 +58,4 @@ jobs:
 
     - name: Check format
       run: |
-        find src tests app -name '*.hs'|xargs -I {} sh -c "cat {}|hindent|~/.cabal/bin/stylish-haskell|diff --color -u {} -"
+        find src tests app -name '*.hs'|xargs -I {} sh -c "cat {}|hindent|stylish-haskell|diff --color -u {} -"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,7 +36,8 @@ jobs:
         sudo apt update
         sudo apt install libsdl2-dev libglew-dev moreutils
         cabal update -j
-        cabal install weeder hlint hindent stylish-haskell -j -z
+        cabal install weeder hlint stylish-haskell -j -z
+        stack install hindent
 
     - name: Generate `cabal.project.local`
       run: "echo \"package * \n  ghc-options: -fwrite-ide-info\" > cabal.project.local"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,8 +36,10 @@ jobs:
         sudo apt update
         sudo apt install libsdl2-dev libglew-dev moreutils
         cabal update -j
-        cabal install weeder hlint -j -z
-        stack install hindent stylish-haskell
+        cabal install weeder -z -j
+        cabal install hlint -z -j
+        cabal install hindent -z -j
+        cabal install stylish-haskell -z -j
 
     - name: Generate `cabal.project.local`
       run: "echo \"package * \n  ghc-options: -fwrite-ide-info\" > cabal.project.local"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -31,6 +31,9 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
         restore-keys: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
 
+    - name: Update the PATH environment variable
+      run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -58,4 +58,4 @@ jobs:
 
     - name: Check format
       run: |
-        find src tests app -name '*.hs'|xargs -I {} sh -c "cat {}|~/.cabal/bin/hindent|~/.cabal/bin/stylish-haskell|diff --color -u {} -"
+        find src tests app -name '*.hs'|xargs -I {} sh -c "cat {}|hindent|~/.cabal/bin/stylish-haskell|diff --color -u {} -"


### PR DESCRIPTION
I guess that when I run `cabal install A B C` cabal tries to resolve dependencies between A, B, and C unnecessarily, causing installing the older version of the packages.