### PR TITLE
Expose the `quests` lens

### DIFF
--- a/src/Gimlight/GameStatus/Exploring.hs
+++ b/src/Gimlight/GameStatus/Exploring.hs
@@ -4,14 +4,13 @@
 module Gimlight.GameStatus.Exploring
     ( ExploringHandler
     , exploringHandler
+    , quests
     , getTileCollection
     , ascendStairsAtPlayerPosition
     , descendStairsAtPlayerPosition
     , exitDungeon
     , doPlayerAction
     , processAfterPlayerTurn
-    , updateQuests
-    , getQuests
     , getPlayerActor
     , getPlayerPosition
     , getCurrentDungeon
@@ -117,12 +116,6 @@ handleNpcTurns eh = (newHandler, killed)
             messageLog %= L.addMessages newLog
     ((dungeonsAfterNpcTurns, killed), newLog) =
         runWriter $ DS.handleNpcTurns (eh ^. tileCollection) (eh ^. dungeons)
-
-updateQuests :: QuestCollection -> ExploringHandler -> ExploringHandler
-updateQuests q e = e & quests .~ q
-
-getQuests :: ExploringHandler -> QuestCollection
-getQuests e = e ^. quests
 
 getPlayerActor :: ExploringHandler -> Maybe Actor
 getPlayerActor = fmap snd . playerActor . (^. cellMap) . getCurrentDungeon

--- a/src/Gimlight/GameStatus/Talking.hs
+++ b/src/Gimlight/GameStatus/Talking.hs
@@ -11,10 +11,10 @@ module Gimlight.GameStatus.Talking
     , selectNextChoice
     ) where
 
+import           Control.Lens                     ((&), (.~), (^.))
 import           GHC.Generics                     (Generic)
 import           Gimlight.Actor                   (Actor)
-import           Gimlight.GameStatus.Exploring    (ExploringHandler, getQuests,
-                                                   updateQuests)
+import           Gimlight.GameStatus.Exploring    (ExploringHandler, quests)
 import           Gimlight.GameStatus.Talking.Part (TalkingPart,
                                                    proceedNonVisiblePartsIfNecessary)
 import qualified Gimlight.GameStatus.Talking.Part as Part
@@ -30,9 +30,9 @@ data TalkingHandler =
 talkingHandler :: Actor -> TalkingPart -> ExploringHandler -> TalkingHandler
 talkingHandler a p h = TalkingHandler a updatedPart updatedHandler
   where
-    updatedHandler = updateQuests updatedQuests h
+    updatedHandler = h & quests .~ updatedQuests
     (updatedPart, updatedQuests) =
-        case proceedNonVisiblePartsIfNecessary (getQuests h) p of
+        case proceedNonVisiblePartsIfNecessary (h ^. quests) p of
             (Just x, h') -> (x, h')
             (Nothing, _) -> error "No part to show."
 
@@ -47,10 +47,10 @@ getExploringHandler (TalkingHandler _ _ h) = h
 
 proceedTalking :: TalkingHandler -> Either ExploringHandler TalkingHandler
 proceedTalking (TalkingHandler a p at) =
-    case Part.proceedTalking (getQuests at) p of
+    case Part.proceedTalking (at ^. quests) p of
         (Just next, updatedQuests) ->
-            Right $ TalkingHandler a next (updateQuests updatedQuests at)
-        (Nothing, updatedQuests) -> Left $ updateQuests updatedQuests at
+            Right $ TalkingHandler a next (at & quests .~ updatedQuests)
+        (Nothing, updatedQuests) -> Left $ at & quests .~ updatedQuests
 
 selectPrevChoice :: TalkingHandler -> TalkingHandler
 selectPrevChoice (TalkingHandler a p at) =


### PR DESCRIPTION
This PR removes `getQuests` and `updateQuests` and instead exposes the
`quests` lens.
