### PR TITLE
`meleeAction` takes `Direction`, not `V2 Int`

### DIFF
--- a/src/Gimlight/Action/Melee.hs
+++ b/src/Gimlight/Action/Melee.hs
@@ -11,7 +11,7 @@ import           Gimlight.Direction        (Direction, toUnitVector)
 import           Gimlight.Dungeon.Map.Cell (locateActorAt, removeActorAt)
 
 meleeAction :: Direction -> Action
-meleeAction offset srcPosition tc cm =
+meleeAction direction srcPosition tc cm =
     case result of
         Right ((l, killed), newMap) -> do
             tell l
@@ -30,4 +30,4 @@ meleeAction offset srcPosition tc cm =
                     locateActorAt tc dstPosition x
                     return (l', [])
                 Nothing -> return (l', [defender])
-    dstPosition = srcPosition + toUnitVector offset
+    dstPosition = srcPosition + toUnitVector direction

--- a/src/Gimlight/Action/Melee.hs
+++ b/src/Gimlight/Action/Melee.hs
@@ -7,10 +7,10 @@ import           Control.Monad.Writer      (runWriter, tell)
 import           Gimlight.Action           (Action, ActionResult (ActionResult),
                                             ActionStatus (Ok))
 import qualified Gimlight.Actor            as A
+import           Gimlight.Direction        (Direction, toUnitVector)
 import           Gimlight.Dungeon.Map.Cell (locateActorAt, removeActorAt)
-import           Linear.V2                 (V2)
 
-meleeAction :: V2 Int -> Action
+meleeAction :: Direction -> Action
 meleeAction offset srcPosition tc cm =
     case result of
         Right ((l, killed), newMap) -> do
@@ -30,4 +30,4 @@ meleeAction offset srcPosition tc cm =
                     locateActorAt tc dstPosition x
                     return (l', [])
                 Nothing -> return (l', [defender])
-    dstPosition = srcPosition + offset
+    dstPosition = srcPosition + toUnitVector offset

--- a/src/Gimlight/NpcBehavior.hs
+++ b/src/Gimlight/NpcBehavior.hs
@@ -105,7 +105,7 @@ selectAction :: Coord -> Actor -> CellMap -> Action
 selectAction position e cm
     | targetIsNextTo position e cm =
         case offsetToTarget position e cm of
-            Just offset -> meleeAction offset
+            Just offset -> meleeAction $ fromUnitVector offset
             Nothing     -> moveOrWait e
     | otherwise = moveOrWait e
 

--- a/src/Gimlight/Player.hs
+++ b/src/Gimlight/Player.hs
@@ -39,7 +39,6 @@ import           Gimlight.GameStatus.SelectingItem (Reason (Drop, Use),
                                                     getSelectingIndex,
                                                     selectingItemHandler)
 import           Gimlight.GameStatus.Talking       (talkingHandler)
-import           Linear.V2                         (V2)
 
 handlePlayerMoving :: Direction -> ExploringHandler -> GameStatus
 handlePlayerMoving dir gs
@@ -93,7 +92,7 @@ playerBumpAction dir eh = action eh
   where
     action =
         case actorAtDestination of
-            Just x  -> meleeOrTalk offset x
+            Just x  -> meleeOrTalk dir x
             Nothing -> moveOrExitMap dir
     actorAtDestination =
         snd <$>
@@ -106,8 +105,8 @@ playerBumpAction dir eh = action eh
             Nothing -> error "The player is dead."
     offset = toUnitVector dir
 
-meleeOrTalk :: V2 Int -> Actor -> ExploringHandler -> (Bool, GameStatus)
-meleeOrTalk offset target eh
+meleeOrTalk :: Direction -> Actor -> ExploringHandler -> (Bool, GameStatus)
+meleeOrTalk dir target eh
     | isMonster target =
         case status of
             Ok               -> (True, Exploring newHandler)
@@ -118,7 +117,7 @@ meleeOrTalk offset target eh
             Just x  -> (True, Talking $ talkingHandler target x eh)
             Nothing -> error "No talk handler is set."
   where
-    (status, newHandler) = doPlayerAction (meleeAction offset) eh
+    (status, newHandler) = doPlayerAction (meleeAction dir) eh
 
 moveOrExitMap :: Direction -> ExploringHandler -> (Bool, GameStatus)
 moveOrExitMap dir eh

--- a/tests/Gimlight/Action/MeleeSpec.hs
+++ b/tests/Gimlight/Action/MeleeSpec.hs
@@ -19,6 +19,7 @@ import           Gimlight.Actor.Identifier     (Identifier (Orc))
 import           Gimlight.Actor.Status         (Status, status)
 import           Gimlight.Actor.Status.Hp      (hp)
 import           Gimlight.Coord                (Coord)
+import           Gimlight.Direction            (Direction (East))
 import           Gimlight.Dungeon.Map.Cell     (CellMap, removeActorAt)
 import           Gimlight.Dungeon.Map.CellSpec (emptyCellMap, locateItemsActors,
                                                 locateItemsActorsST)
@@ -90,5 +91,5 @@ atkPos = V2 0 0
 defPos :: Coord
 defPos = V2 1 0
 
-offset :: V2 Int
-offset = defPos - atkPos
+offset :: Direction
+offset = East

--- a/tests/Gimlight/Action/MeleeSpec.hs
+++ b/tests/Gimlight/Action/MeleeSpec.hs
@@ -68,7 +68,7 @@ testMap st =
         (,) <$> testMonster (status (hp 1) 2 0) <*> testMonster st
 
 result :: CellMap -> ActionResultWithLog
-result = meleeAction offset atkPos mockTileCollection
+result = meleeAction East atkPos mockTileCollection
 
 defenderAfterAttackAndLog :: CellMap -> (Maybe Actor, MessageLog)
 defenderAfterAttackAndLog cm = (d, l)
@@ -90,6 +90,3 @@ atkPos = V2 0 0
 
 defPos :: Coord
 defPos = V2 1 0
-
-offset :: Direction
-offset = East


### PR DESCRIPTION
It is useful to implement using the walking images. When an actor
melees, he or she will face to the direction.
