### PR TITLE
Separate CI process into two parts

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,45 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: haskell/actions/setup@v1
+      with:
+        ghc-version: '8.10.7'
+        cabal-version: '3.6.0.0'
+
+    - name: Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-cabal
+      with:
+        path: |
+          ~/.cabal/packages
+          ~/.cabal/store
+          dist-newstyle
+        key: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install libsdl2-dev libglew-dev moreutils
+        cabal update -j
+
+    - name: Build
+      run: |
+        cabal clean # This is needed to run `weeder` correctly.
+        cabal build --enable-tests --enable-benchmarks all -j
+
+    - name: Run tests
+      run: cabal test all -j
+
+  format_and_lint:
 
     runs-on: ubuntu-latest
 
@@ -38,28 +76,25 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libsdl2-dev libglew-dev moreutils
-        cabal update -j
-        cabal install weeder -z -j
-        cabal install hlint -z -j
-        cabal install hindent -z -j
-        cabal install stylish-haskell -z -j
 
-    - name: Generate `cabal.project.local`
+        cabal update -j
+
+        # See https://tokuchan3515.hatenablog.com/entry/2022/03/26/133158 why we separate `cabal install`s.
+        cabal install weeder -j -z
+        cabal install hlint -j -z
+        cabal install hindent -j -z
+        cabal install stylish-haskell -j -z
+
+    - name: Generate `cabal.project.local` for `weeder`
       run: "echo \"package * \n  ghc-options: -fwrite-ide-info\" > cabal.project.local"
 
-    - name: Build
-      run: |
-        cabal clean # This is needed to run `weeder` correctly.
-        cabal build --enable-tests --enable-benchmarks all -j
-
     - name: Detect unused lines
-      run: ~/.cabal/bin/weeder
-
-    - name: Run tests
-      run: cabal test all -j
+      run: weeder
 
     - name: Run hlint
-      run: ~/.cabal/bin/hlint .
+      run: hlint .
 
     - name: Check format
       run: ./formatter.sh --check
+
+


### PR DESCRIPTION
It is to prepare CI for Windows. We don't have to run the formatter and
code checkers on more than one OSes.
