### PR TITLE
Prepend the job id to the cache key

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -68,8 +68,8 @@ jobs:
           ~/.cabal/packages
           ~/.cabal/store
           dist-newstyle
-        key: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        restore-keys: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: Install dependencies (Linux)
       run: |
@@ -107,8 +107,8 @@ jobs:
           ~/.cabal/packages
           ~/.cabal/store
           dist-newstyle
-        key: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+        key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        restore-keys: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: Update the PATH environment variable
       run: echo "$HOME/.cabal/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Each job shares the cache namespaces, and GA stores only the first one
out of the caches with the same names. This commit prepends the job name
to the cache key to prevent conflicts.
