### PR TITLE
Specify paths that actually exist

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -65,8 +65,7 @@ jobs:
         cache-name: cache-cabal
       with:
         path: |
-          ~/.cabal/packages
-          ~/.cabal/store
+          ${{ steps.haskell_setup.outputs.cabal-store }}
           dist-newstyle
         key: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
         restore-keys: ${{ github.job }}-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}


### PR DESCRIPTION
The previous caching method did not work on Windows because the paths
were wrong. This commit specifies the `.cabal/store` directory path
based on the output of `haskell/actions/setup`. We no longer save the
contents of `.cabal/packages`, but I think it is fine because the
`packages` directory only contains packages' tarballs.
