### PR TITLE
Remove `readTileFileRecursive`

### DIFF
--- a/src/Gimlight/Dungeon/Map/Tile/JSONReader.hs
+++ b/src/Gimlight/Dungeon/Map/Tile/JSONReader.hs
@@ -1,40 +1,32 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Gimlight.Dungeon.Map.Tile.JSONReader
-    ( readTileFileRecursive
-    , addTileFile
+    ( addTileFile
     ) where
 
-import           Codec.Picture              (Image (imageData, imageHeight, imageWidth),
-                                             PixelRGBA8, convertRGBA8,
-                                             readImage)
-import           Codec.Picture.Extra        (crop, flipHorizontally,
-                                             flipVertically)
-import           Control.Applicative        (ZipList (ZipList, getZipList))
-import           Control.Lens               (filtered, has, only, (&), (^..),
-                                             (^?))
-import           Control.Monad              (guard, unless)
-import           Data.Aeson.Lens            (_Bool, _Integer, _String, key,
-                                             values)
-import           Data.Bits                  (Bits (bit), (.|.))
-import           Data.Either                (fromRight)
-import           Data.Foldable              (foldlM)
-import           Data.List                  (transpose)
-import           Data.List.Split            (chunksOf)
-import           Data.Map                   (empty, insert)
-import           Data.Text                  (Text, unpack)
-import qualified Data.Vector.Storable       as V
-import           Gimlight.Data.Maybe        (expectJust)
-import           Gimlight.Dungeon.Map.Tile  (Tile, TileCollection, getImage,
-                                             isTransparent, isWalkable, tile)
-import           Gimlight.System.Path       (canonicalizeToUnixStyleRelativePath)
-import           Gimlight.UI.Draw.Config    (tileHeight, tileWidth)
-import           System.Directory.Recursive (getFilesRecursive)
-import           System.FilePath            (dropFileName, (</>))
-
-readTileFileRecursive :: FilePath -> IO TileCollection
-readTileFileRecursive dir =
-    getFilesRecursive dir >>= foldlM (flip addTileFile) empty
+import           Codec.Picture             (Image (imageData, imageHeight, imageWidth),
+                                            PixelRGBA8, convertRGBA8, readImage)
+import           Codec.Picture.Extra       (crop, flipHorizontally,
+                                            flipVertically)
+import           Control.Applicative       (ZipList (ZipList, getZipList))
+import           Control.Lens              (filtered, has, only, (&), (^..),
+                                            (^?))
+import           Control.Monad             (guard, unless)
+import           Data.Aeson.Lens           (_Bool, _Integer, _String, key,
+                                            values)
+import           Data.Bits                 (Bits (bit), (.|.))
+import           Data.Either               (fromRight)
+import           Data.List                 (transpose)
+import           Data.List.Split           (chunksOf)
+import           Data.Map                  (insert)
+import           Data.Text                 (Text, unpack)
+import qualified Data.Vector.Storable      as V
+import           Gimlight.Data.Maybe       (expectJust)
+import           Gimlight.Dungeon.Map.Tile (Tile, TileCollection, getImage,
+                                            isTransparent, isWalkable, tile)
+import           Gimlight.System.Path      (canonicalizeToUnixStyleRelativePath)
+import           Gimlight.UI.Draw.Config   (tileHeight, tileWidth)
+import           System.FilePath           (dropFileName, (</>))
 
 addTileFile :: FilePath -> TileCollection -> IO TileCollection
 addTileFile path tc = do

--- a/src/Gimlight/Dungeon/Map/Tile/JSONReader.hs
+++ b/src/Gimlight/Dungeon/Map/Tile/JSONReader.hs
@@ -2,6 +2,7 @@
 
 module Gimlight.Dungeon.Map.Tile.JSONReader
     ( readTileFileRecursive
+    , addTileFile
     ) where
 
 import           Codec.Picture              (Image (imageData, imageHeight, imageWidth),

--- a/src/Gimlight/GameStatus.hs
+++ b/src/Gimlight/GameStatus.hs
@@ -10,7 +10,9 @@ module Gimlight.GameStatus
 import           Control.Lens                          ()
 import           Control.Monad.State                   (StateT (runStateT),
                                                         evalState, evalStateT)
+import           Data.Foldable                         (foldlM)
 import           Data.List.NonEmpty                    (fromList)
+import           Data.Map                              (empty)
 import           Data.Tree                             (Tree (Node, rootLabel, subForest))
 import           GHC.Generics                          (Generic)
 import           Gimlight.Actor.WalkingImages          (readIntegratedImagesRecursive)
@@ -18,7 +20,7 @@ import           Gimlight.Data.Maybe                   (expectJust)
 import           Gimlight.Dungeon                      (addAscendingAndDescendingStiars,
                                                         addDescendingStairs)
 import           Gimlight.Dungeon.Init                 (initDungeon)
-import           Gimlight.Dungeon.Map.Tile.JSONReader  (readTileFileRecursive)
+import           Gimlight.Dungeon.Map.Tile.JSONReader  (addTileFile)
 import           Gimlight.Dungeon.Predefined.BatsCave  (batsDungeon)
 import           Gimlight.Dungeon.Predefined.GlobalMap (globalMap)
 import           Gimlight.Dungeon.Stairs               (StairsPair (StairsPair))
@@ -37,6 +39,7 @@ import           Gimlight.Quest                        (questCollection)
 import           Gimlight.TreeZipper                   (appendTree, goDownBy,
                                                         treeZipper)
 import           Linear.V2                             (V2 (V2))
+import           System.Directory.Recursive            (getFilesRecursive)
 import           System.Random                         (getStdGen)
 
 data GameStatus
@@ -53,7 +56,7 @@ data GameStatus
 newGameStatus :: IO GameStatus
 newGameStatus = do
     g <- getStdGen
-    tc <- readTileFileRecursive "tiles/"
+    tc <- getFilesRecursive "tiles/" >>= foldlM (flip addTileFile) empty
     walkingImages <- readIntegratedImagesRecursive "images/walking_pictures/"
     gm <- globalMap
     (beaeve, ig) <- runStateT (initDungeon tc) generator

--- a/tests/Gimlight/Dungeon/GenerateSpec.hs
+++ b/tests/Gimlight/Dungeon/GenerateSpec.hs
@@ -34,7 +34,7 @@ import           Test.Hspec.QuickCheck                (prop)
 
 spec :: Spec
 spec = do
-    tc <- runIO $ addTileFile "tests/tiles/valid/generate.json" empty
+    tc <- runIO $ addTileFile "tests/tiles/generate.json" empty
     expected <- runIO $ readMapFile "tests/maps/generate/seed_0.json"
     let result = generateSingleMap 0 tc
     describe "generateMultipleFloorsDungeon" $ do

--- a/tests/Gimlight/Dungeon/GenerateSpec.hs
+++ b/tests/Gimlight/Dungeon/GenerateSpec.hs
@@ -6,6 +6,7 @@ import           Control.Lens                         (Ixed (ix), view, (^.),
                                                        (^?))
 import           Control.Monad.State                  (State, StateT, evalState,
                                                        evalStateT)
+import           Data.Map                             (empty)
 import           Data.Tree                            (Tree (Node))
 import           Gimlight.Coord                       (Coord)
 import           Gimlight.Dungeon                     (Dungeon)
@@ -20,7 +21,7 @@ import           Gimlight.Dungeon.Map.Cell            (CellMap, actorExists,
                                                        upper)
 import           Gimlight.Dungeon.Map.JSONReader      (readMapFile)
 import           Gimlight.Dungeon.Map.Tile            (TileCollection)
-import           Gimlight.Dungeon.Map.Tile.JSONReader (readTileFileRecursive)
+import           Gimlight.Dungeon.Map.Tile.JSONReader (addTileFile)
 import           Gimlight.IndexGenerator              (IndexGenerator,
                                                        generator)
 import           Gimlight.SetUp.TileFile              (tileFileForGeneration)
@@ -33,7 +34,7 @@ import           Test.Hspec.QuickCheck                (prop)
 
 spec :: Spec
 spec = do
-    tc <- runIO $ readTileFileRecursive "tests/tiles/valid/"
+    tc <- runIO $ addTileFile "tests/tiles/valid/generate.json" empty
     expected <- runIO $ readMapFile "tests/maps/generate/seed_0.json"
     let result = generateSingleMap 0 tc
     describe "generateMultipleFloorsDungeon" $ do

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -31,17 +31,17 @@ testAddTileFile =
         e <- liftIO expected
         result `shouldBe` e
     testFileAndExpected =
-        [ ("tests/tiles/valid/united.json", tilesInUnitedTileFile)
-        , ("tests/tiles/valid/single.json", tilesInSingleTileFile)
-        , ("tests/tiles/valid/unwalkable.json", tilesInUnwalkableTileFile)
-        , ("tests/tiles/valid/haskell.json", haskellTile)
-        , ("tests/tiles/valid/generate.json", generateTile)
+        [ ("tests/tiles/united.json", tilesInUnitedTileFile)
+        , ("tests/tiles/single.json", tilesInSingleTileFile)
+        , ("tests/tiles/unwalkable.json", tilesInUnwalkableTileFile)
+        , ("tests/tiles/haskell.json", haskellTile)
+        , ("tests/tiles/generate.json", generateTile)
         ]
 
 testErrorOnReadingTileWithoutProperties :: Spec
 testErrorOnReadingTileWithoutProperties =
     describe "addTileFile" $
     it "panics if it tries to read a tile that misses necessary proeprties." $
-    addTileFile "tests/tiles/invalid/no_properties.json" empty `shouldThrow`
+    addTileFile "tests/tiles/no_properties.json" empty `shouldThrow`
     errorCall
         (tileWithoutProperties ++ ": Some tiles miss necessary properties.")

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -37,6 +37,7 @@ testAddTileFile =
         , ("tests/tiles/valid/single.json", tilesInSingleTileFile)
         , ("tests/tiles/valid/unwalkable.json", tilesInUnwalkableTileFile)
         , ("tests/tiles/valid/haskell.json", haskellTile)
+        , ("tests/tiles/valid/generate.json", generateTile)
         ]
 
 testReadTileFilesRecursive :: Spec

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -3,9 +3,8 @@ module Gimlight.Dungeon.Map.Tile.JSONReaderSpec
     ) where
 
 import           Control.Monad.IO.Class               (liftIO)
-import           Data.Map                             (empty, unions)
-import           Gimlight.Dungeon.Map.Tile.JSONReader (addTileFile,
-                                                       readTileFileRecursive)
+import           Data.Map                             (empty)
+import           Gimlight.Dungeon.Map.Tile.JSONReader (addTileFile)
 import           Gimlight.SetUp.TileFile              (generateTile,
                                                        haskellTile,
                                                        tileWithoutProperties,
@@ -13,13 +12,12 @@ import           Gimlight.SetUp.TileFile              (generateTile,
                                                        tilesInUnitedTileFile,
                                                        tilesInUnwalkableTileFile)
 import           Test.Hspec                           (Spec, describe,
-                                                       errorCall, it, runIO,
-                                                       shouldBe, shouldThrow)
+                                                       errorCall, it, shouldBe,
+                                                       shouldThrow)
 
 spec :: Spec
 spec = do
     testAddTileFile
-    testReadTileFilesRecursive
     testErrorOnReadingTileWithoutProperties
 
 testAddTileFile :: Spec
@@ -38,22 +36,6 @@ testAddTileFile =
         , ("tests/tiles/valid/unwalkable.json", tilesInUnwalkableTileFile)
         , ("tests/tiles/valid/haskell.json", haskellTile)
         , ("tests/tiles/valid/generate.json", generateTile)
-        ]
-
-testReadTileFilesRecursive :: Spec
-testReadTileFilesRecursive = do
-    expected <- runIO $ unions <$> sequence tiles
-    result <- runIO $ readTileFileRecursive "tests/tiles/valid/"
-    describe "readTileFilesRecursive" $
-        it "reads all tile files in a directory recursively." $
-        result `shouldBe` expected
-  where
-    tiles =
-        [ tilesInUnitedTileFile
-        , tilesInSingleTileFile
-        , tilesInUnwalkableTileFile
-        , haskellTile
-        , generateTile
         ]
 
 testErrorOnReadingTileWithoutProperties :: Spec

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -35,6 +35,7 @@ testAddTileFile =
     testFileAndExpected =
         [ ("tests/tiles/valid/united.json", tilesInUnitedTileFile)
         , ("tests/tiles/valid/single.json", tilesInSingleTileFile)
+        , ("tests/tiles/valid/unwalkable.json", tilesInUnwalkableTileFile)
         ]
 
 testReadTileFilesRecursive :: Spec

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -36,6 +36,7 @@ testAddTileFile =
         [ ("tests/tiles/valid/united.json", tilesInUnitedTileFile)
         , ("tests/tiles/valid/single.json", tilesInSingleTileFile)
         , ("tests/tiles/valid/unwalkable.json", tilesInUnwalkableTileFile)
+        , ("tests/tiles/valid/haskell.json", haskellTile)
         ]
 
 testReadTileFilesRecursive :: Spec

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -2,8 +2,10 @@ module Gimlight.Dungeon.Map.Tile.JSONReaderSpec
     ( spec
     ) where
 
-import           Data.Map                             (unions)
-import           Gimlight.Dungeon.Map.Tile.JSONReader (readTileFileRecursive)
+import           Control.Monad.IO.Class               (liftIO)
+import           Data.Map                             (empty, unions)
+import           Gimlight.Dungeon.Map.Tile.JSONReader (addTileFile,
+                                                       readTileFileRecursive)
 import           Gimlight.SetUp.TileFile              (generateTile,
                                                        haskellTile,
                                                        tileWithoutProperties,
@@ -16,8 +18,17 @@ import           Test.Hspec                           (Spec, describe,
 
 spec :: Spec
 spec = do
+    testAddTileFile
     testReadTileFilesRecursive
     testErrorOnReadingTileWithoutProperties
+
+testAddTileFile :: Spec
+testAddTileFile =
+    describe "addTileFile" $
+    it "reads the tile file specified by an argument and add it to the given tile collection." $ do
+        expected <- liftIO tilesInUnitedTileFile
+        result <- liftIO $ addTileFile "tests/tiles/valid/united.json" empty
+        result `shouldBe` expected
 
 testReadTileFilesRecursive :: Spec
 testReadTileFilesRecursive = do

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -26,8 +26,8 @@ testAddTileFile :: Spec
 testAddTileFile =
     describe "addTileFile" $
     it "reads the tile file specified by an argument and add it to the given tile collection." $ do
-        expected <- liftIO tilesInUnitedTileFile
         result <- liftIO $ addTileFile "tests/tiles/valid/united.json" empty
+        expected <- liftIO tilesInUnitedTileFile
         result `shouldBe` expected
 
 testReadTileFilesRecursive :: Spec

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -29,6 +29,9 @@ testAddTileFile =
         result <- liftIO $ addTileFile "tests/tiles/valid/united.json" empty
         expected <- liftIO tilesInUnitedTileFile
         result `shouldBe` expected
+        result2 <- liftIO $ addTileFile "tests/tiles/valid/single.json" empty
+        expected2 <- liftIO tilesInSingleTileFile
+        result2 `shouldBe` expected2
 
 testReadTileFilesRecursive :: Spec
 testReadTileFilesRecursive = do

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -60,6 +60,6 @@ testErrorOnReadingTileWithoutProperties :: Spec
 testErrorOnReadingTileWithoutProperties =
     describe "addTileFile" $
     it "panics if it tries to read a tile that misses necessary proeprties." $
-    readTileFileRecursive "tests/tiles/invalid/" `shouldThrow`
+    addTileFile "tests/tiles/invalid/no_properties.json" empty `shouldThrow`
     errorCall
         (tileWithoutProperties ++ ": Some tiles miss necessary properties.")

--- a/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
+++ b/tests/Gimlight/Dungeon/Map/Tile/JSONReaderSpec.hs
@@ -25,13 +25,17 @@ spec = do
 testAddTileFile :: Spec
 testAddTileFile =
     describe "addTileFile" $
-    it "reads the tile file specified by an argument and add it to the given tile collection." $ do
-        result <- liftIO $ addTileFile "tests/tiles/valid/united.json" empty
-        expected <- liftIO tilesInUnitedTileFile
-        result `shouldBe` expected
-        result2 <- liftIO $ addTileFile "tests/tiles/valid/single.json" empty
-        expected2 <- liftIO tilesInSingleTileFile
-        result2 `shouldBe` expected2
+    it "reads the tile file specified by an argument and add it to the given tile collection." $
+    mapM_ testFunc testFileAndExpected
+  where
+    testFunc (path, expected) = do
+        result <- liftIO $ addTileFile path empty
+        e <- liftIO expected
+        result `shouldBe` e
+    testFileAndExpected =
+        [ ("tests/tiles/valid/united.json", tilesInUnitedTileFile)
+        , ("tests/tiles/valid/single.json", tilesInSingleTileFile)
+        ]
 
 testReadTileFilesRecursive :: Spec
 testReadTileFilesRecursive = do

--- a/tests/Gimlight/SetUp/TileFile.hs
+++ b/tests/Gimlight/SetUp/TileFile.hs
@@ -67,22 +67,22 @@ generateTile = fromList <$> foldlM foldStep [] [0 .. 29]
     unwalkableAndUntransparentTiles = [1 .. 21]
 
 unitedTileFile :: FilePath
-unitedTileFile = "tests/tiles/valid/united.json"
+unitedTileFile = "tests/tiles/united.json"
 
 singleTileFile :: FilePath
-singleTileFile = "tests/tiles/valid/single.json"
+singleTileFile = "tests/tiles/single.json"
 
 unwalkableTileFile :: FilePath
-unwalkableTileFile = "tests/tiles/valid/unwalkable.json"
+unwalkableTileFile = "tests/tiles/unwalkable.json"
 
 haskellTilePath :: FilePath
-haskellTilePath = "tests/tiles/valid/haskell.json"
+haskellTilePath = "tests/tiles/haskell.json"
 
 tileWithoutProperties :: FilePath
-tileWithoutProperties = "tests/tiles/invalid/no_properties.json"
+tileWithoutProperties = "tests/tiles/no_properties.json"
 
 tileFileForGeneration :: FilePath
-tileFileForGeneration = "tests/tiles/valid/generate.json"
+tileFileForGeneration = "tests/tiles/generate.json"
 
 -- Transformation order is important. Tiled's specification says
 --

--- a/tests/maps/generate/seed_0.json
+++ b/tests/maps/generate/seed_0.json
@@ -35,7 +35,7 @@
  "tilesets":[
         {
          "firstgid":1,
-         "source":"..\/..\/tiles\/valid\/generate.json"
+         "source":"..\/..\/tiles\/generate.json"
         }],
  "tilewidth":48,
  "type":"map",

--- a/tests/maps/multiple_tile_files.json
+++ b/tests/maps/multiple_tile_files.json
@@ -13,7 +13,7 @@
          "width":2,
          "x":0,
          "y":0
-        }, 
+        },
         {
          "data":[0, 0],
          "height":1,
@@ -35,11 +35,11 @@
  "tilesets":[
         {
          "firstgid":1,
-         "source":"..\/tiles\/valid\/united.json"
-        }, 
+         "source":"..\/tiles\/united.json"
+        },
         {
          "firstgid":7,
-         "source":"..\/tiles\/valid\/single.json"
+         "source":"..\/tiles\/single.json"
         }],
  "tilewidth":48,
  "type":"map",

--- a/tests/maps/not_square.json
+++ b/tests/maps/not_square.json
@@ -13,7 +13,7 @@
          "width":2,
          "x":0,
          "y":0
-        }, 
+        },
         {
          "data":[0, 0],
          "height":1,
@@ -35,7 +35,7 @@
  "tilesets":[
         {
          "firstgid":1,
-         "source":"..\/tiles\/valid\/single.json"
+         "source":"..\/tiles\/single.json"
         }],
  "tilewidth":48,
  "type":"map",

--- a/tests/maps/rotation.json
+++ b/tests/maps/rotation.json
@@ -35,7 +35,7 @@
  "tilesets":[
         {
          "firstgid":1,
-         "source":"..\/tiles\/valid\/haskell.json"
+         "source":"..\/tiles\/haskell.json"
         }],
  "tilewidth":48,
  "type":"map",

--- a/tests/maps/single_tile.json
+++ b/tests/maps/single_tile.json
@@ -13,7 +13,7 @@
          "width":1,
          "x":0,
          "y":0
-        }, 
+        },
         {
          "data":[0],
          "height":1,
@@ -35,7 +35,7 @@
  "tilesets":[
         {
          "firstgid":1,
-         "source":"..\/tiles\/valid\/single.json"
+         "source":"..\/tiles\/single.json"
         }],
  "tilewidth":48,
  "type":"map",

--- a/tests/maps/transform_and_rotation.json
+++ b/tests/maps/transform_and_rotation.json
@@ -35,11 +35,11 @@
  "tilesets":[
         {
          "firstgid":1,
-         "source":"..\/tiles\/valid\/haskell.json"
+         "source":"..\/tiles\/haskell.json"
         },
         {
          "firstgid":2,
-         "source":"..\/tiles\/valid\/single.json"
+         "source":"..\/tiles\/single.json"
         }],
  "tilewidth":48,
  "type":"map",

--- a/tests/tiles/generate.json
+++ b/tests/tiles/generate.json
@@ -1,5 +1,5 @@
 { "columns":15,
- "image":"..\/..\/images\/tiles\/generate.png",
+ "image":"..\/images\/tiles\/generate.png",
  "imageheight":96,
  "imagewidth":720,
  "margin":0,
@@ -16,13 +16,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":1,
          "properties":[
@@ -30,13 +30,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":2,
          "properties":[
@@ -44,13 +44,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":3,
          "properties":[
@@ -58,13 +58,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":4,
          "properties":[
@@ -72,13 +72,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":5,
          "properties":[
@@ -86,13 +86,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":6,
          "properties":[
@@ -100,13 +100,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":7,
          "properties":[
@@ -114,13 +114,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":8,
          "properties":[
@@ -128,13 +128,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":9,
          "properties":[
@@ -142,13 +142,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":10,
          "properties":[
@@ -156,13 +156,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":11,
          "properties":[
@@ -170,13 +170,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":12,
          "properties":[
@@ -184,13 +184,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":13,
          "properties":[
@@ -198,13 +198,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":14,
          "properties":[
@@ -212,13 +212,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":15,
          "properties":[
@@ -226,13 +226,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":16,
          "properties":[
@@ -240,13 +240,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":17,
          "properties":[
@@ -254,13 +254,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":18,
          "properties":[
@@ -268,13 +268,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":19,
          "properties":[
@@ -282,13 +282,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":20,
          "properties":[
@@ -296,13 +296,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":21,
          "properties":[
@@ -310,13 +310,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":22,
          "properties":[
@@ -324,13 +324,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":23,
          "properties":[
@@ -338,13 +338,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":24,
          "properties":[
@@ -352,13 +352,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":25,
          "properties":[
@@ -366,13 +366,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":26,
          "properties":[
@@ -380,13 +380,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":27,
          "properties":[
@@ -394,13 +394,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":28,
          "properties":[
@@ -408,13 +408,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":29,
          "properties":[
@@ -422,7 +422,7 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
@@ -455,55 +455,55 @@
                 {
                  "tileid":1,
                  "wangid":[1, 0, 0, 0, 0, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":2,
                  "wangid":[1, 0, 1, 0, 0, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":3,
                  "wangid":[1, 1, 1, 0, 0, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":4,
                  "wangid":[1, 0, 0, 0, 1, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":5,
                  "wangid":[1, 0, 1, 0, 1, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":6,
                  "wangid":[1, 1, 1, 0, 1, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":7,
                  "wangid":[1, 0, 1, 1, 1, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":8,
                  "wangid":[1, 1, 1, 1, 1, 0, 0, 0]
-                }, 
+                },
                 {
                  "tileid":9,
                  "wangid":[1, 0, 1, 0, 1, 0, 1, 0]
-                }, 
+                },
                 {
                  "tileid":10,
                  "wangid":[1, 1, 1, 0, 1, 0, 1, 0]
-                }, 
+                },
                 {
                  "tileid":11,
                  "wangid":[1, 0, 1, 1, 1, 0, 1, 0]
-                }, 
+                },
                 {
                  "tileid":12,
                  "wangid":[1, 1, 1, 0, 1, 1, 1, 0]
-                }, 
+                },
                 {
                  "tileid":13,
                  "wangid":[1, 1, 1, 1, 1, 1, 1, 0]
-                }, 
+                },
                 {
                  "tileid":14,
                  "wangid":[1, 1, 1, 1, 1, 1, 1, 1]

--- a/tests/tiles/haskell.json
+++ b/tests/tiles/haskell.json
@@ -1,5 +1,5 @@
 { "columns":1,
- "image":"..\/..\/images\/tiles\/haskell.png",
+ "image":"..\/images\/tiles\/haskell.png",
  "imageheight":48,
  "imagewidth":48,
  "margin":0,
@@ -16,7 +16,7 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",

--- a/tests/tiles/no_properties.json
+++ b/tests/tiles/no_properties.json
@@ -1,5 +1,5 @@
 { "columns":1,
- "image":"..\/..\/images\/tiles\/haskell.png",
+ "image":"..\/images\/tiles\/haskell.png",
  "imageheight":48,
  "imagewidth":48,
  "margin":0,

--- a/tests/tiles/single.json
+++ b/tests/tiles/single.json
@@ -1,5 +1,5 @@
 { "columns":1,
- "image":"..\/..\/images\/tiles\/single_0.png",
+ "image":"..\/images\/tiles\/single_0.png",
  "imageheight":48,
  "imagewidth":48,
  "margin":0,
@@ -9,7 +9,7 @@
          "name":"transparent",
          "type":"bool",
          "value":true
-        }, 
+        },
         {
          "name":"walkable",
          "type":"bool",
@@ -27,7 +27,7 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",

--- a/tests/tiles/united.json
+++ b/tests/tiles/united.json
@@ -1,5 +1,5 @@
 { "columns":3,
- "image":"..\/..\/images\/tiles\/united.png",
+ "image":"..\/images\/tiles\/united.png",
  "imageheight":96,
  "imagewidth":144,
  "margin":0,
@@ -16,13 +16,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":1,
          "properties":[
@@ -30,13 +30,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":2,
          "properties":[
@@ -44,13 +44,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":false
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":false
                 }]
-        }, 
+        },
         {
          "id":3,
          "properties":[
@@ -58,13 +58,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":4,
          "properties":[
@@ -72,13 +72,13 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",
                  "value":true
                 }]
-        }, 
+        },
         {
          "id":5,
          "properties":[
@@ -86,7 +86,7 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",

--- a/tests/tiles/unwalkable.json
+++ b/tests/tiles/unwalkable.json
@@ -1,5 +1,5 @@
 { "columns":1,
- "image":"..\/..\/images\/tiles\/single_0.png",
+ "image":"..\/images\/tiles\/single_0.png",
  "imageheight":48,
  "imagewidth":48,
  "margin":0,
@@ -16,7 +16,7 @@
                  "name":"transparent",
                  "type":"bool",
                  "value":true
-                }, 
+                },
                 {
                  "name":"walkable",
                  "type":"bool",


### PR DESCRIPTION
`readTileFileRecursive` is difficult to test. We must create all the expected tile structures even if we do not test some of them. Especially, it is difficult to create a test case for generation tiles because we will change their structure, and generation tiles will have 47+ tiles.
That is why we expose `addTileFile`.
