### PR TITLE
Specify `-Weverything -Werror` in `stack.yaml`

### DIFF
--- a/gimlight.cabal
+++ b/gimlight.cabal
@@ -34,7 +34,6 @@ library
       Paths_gimlight
   hs-source-dirs:
       src
-  ghc-options: -Weverything -Werror
   build-depends:
       base >=4.7 && <5
   default-language: Haskell2010
@@ -47,7 +46,7 @@ executable gimlight-exe
       Paths_gimlight
   hs-source-dirs:
       app
-  ghc-options: -Weverything -Werror -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , gimlight
@@ -62,7 +61,7 @@ test-suite gimlight-test
       Paths_gimlight
   hs-source-dirs:
       test
-  ghc-options: -Weverything -Werror -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -18,10 +18,6 @@ description: Please see the README on GitHub at <https://github.com/toku-sa-n/gi
 dependencies:
   - base >= 4.7 && < 5
 
-ghc-options:
-  - -Weverything
-  - -Werror
-
 library:
   source-dirs: src
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,7 @@ resolver: lts-22.15
 packages:
   - .
 
+ghc-options:
+  "$locals": -Weverything -Werror
+
 system-ghc: true


### PR DESCRIPTION
Libraries with `-Werror` may not compile in the future as a new warning
is enabled in the compiler, and should be specified outside of the
library configuration. I moved `-Weverything` for just consistency.
