### PR TITLE
Let `trailing-newline` not fail with submodules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,8 +226,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
+      # Do not try to merge two `xargs` like this because it will fail with submodules as the last `||` catches cases where the first two test commands fail.
+      #
+      # ```bash
+      # git ls-files | xargs -I {} sh -c '[ ! -d "{}" ] && [ -s "{}" ] && tail -c 1 {} | read -r _ || (echo "{}"; false)'
+      # ```
       - name: List all non-empty files tracked by git that do not end with a newline
-        run: git ls-files | xargs -I {} sh -c '[ ! -d "{}" ] && [ -s "{}" ] && tail -c 1 {} | read -r _ || (echo "{}"; false)'
+        run: git ls-files | xargs -I {} sh -c '[ ! -d "{}" ] && [ -s "{}" ] echo {}' | xargs -I {} sh -c 'tail -c 1 {} | read -r _ || (echo "{}"; false)'
 
   weeder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes: #67
