### PR TITLE
feat!: restrict to `ocaml >= 4.14.1`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,8 @@
   (ctypes-foreign
    (= 0.18.0))
   dune
-  ocaml
+  (ocaml
+   (>= 4.14.1))
   (tsdl
    (= 0.9.8))
   zarith)


### PR DESCRIPTION
My computer still uses OCaml 4.14.1.
