### PR TITLE
refactor: export only one OCaml file

### DIFF
--- a/src/extraction/Extraction.v
+++ b/src/extraction/Extraction.v
@@ -6,4 +6,12 @@ From Gimlight Require Import GameModel.
 
 Extraction Language OCaml.
 
-Separate Extraction game_model init_game_model increment get_count.
+(* 
+  Note: We use `Extraction` instead of `Separate Extraction` due to current limitations in Dune's handling of nested modules. 
+  Specifically, Dune's `coq.extraction` stanza does not support specifying modules located in subdirectories within the `extracted_modules` field. 
+  This limitation is documented in the Dune issue tracker: https://github.com/ocaml/dune/issues/10679
+
+  To maintain a manageable project structure without flattening our directory hierarchy, we opt to extract all definitions into a single OCaml file. 
+  This approach simplifies the build process and avoids potential complications associated with unsupported nested module extractions.
+*)
+Extraction "Core.ml" game_model init_game_model increment get_count.

--- a/src/extraction/dune
+++ b/src/extraction/dune
@@ -4,7 +4,7 @@
 
 (coq.extraction
  (prelude Extraction)
- (extracted_modules BinInt BinPos GameModel)
+ (extracted_modules Core)
  (theories Gimlight))
 
 (env

--- a/src/wrapper/game_model.ml
+++ b/src/wrapper/game_model.ml
@@ -1,5 +1,5 @@
-type game_model = Core.GameModel.game_model
+type game_model = Core.game_model
 
-let init_game_model = Core.GameModel.init_game_model
-let increment = Core.GameModel.increment
-let get_count = Core.GameModel.get_count
+let init_game_model = Core.init_game_model
+let increment = Core.increment
+let get_count = Core.get_count


### PR DESCRIPTION
See the code comment in `src/extraction/Extraction.v`.