### PR TITLE
Revert "refactor: remove `FixedSizeArray.make_nonempty` (#142)"

### DIFF
--- a/src/lib/Kernel/Coquill/FixedSizeArray.v
+++ b/src/lib/Kernel/Coquill/FixedSizeArray.v
@@ -43,22 +43,35 @@ Section Append.
   Qed.
 End Append.
 
-Section Make.
+Section MakeNonempty.
   Context {A : Type}.
 
-  Program Fixpoint make {A : Type} (n : N) (x : A) {measure (N.to_nat n)} : t A n :=
+  Program Fixpoint make_nonempty (n : positive) (x : A) : t A (N.pos n) :=
     match n with
-    | 0 => empty
-    | N.pos _ => x :|: make (N.pred n) x
+    | xH => [| x |]
+    | xO n' => append (make_nonempty n' x) (make_nonempty n' x)
+    | xI n' => x :|: append (make_nonempty n' x) (make_nonempty n' x)
     end.
   Next Obligation.
   Proof.
-    lia.
+    f_equal.
+    apply Pos.add_diag.
   Qed.
   Next Obligation.
   Proof.
-    lia.
+    f_equal.
+    now rewrite Pos.add_diag.
   Qed.
+End MakeNonempty.
+
+Section Make.
+  Context {A : Type}.
+
+  Definition make {A : Type} (n : N) (x : A) : t A n :=
+    match n with
+    | 0 => empty
+    | Npos n' => make_nonempty n' x
+    end.
 
   Theorem make_0_eq_empty : forall {A : Type} (x : A), make 0 x = [| |].
   Proof.


### PR DESCRIPTION
This reverts commit db68e4839b41dbe2d1b568af2a1d24a6e8073cb7.
